### PR TITLE
normalized changelog format and fixed incorrect versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
-# Change Log
+# v 0.3.5 (?)
+Changes in this release:
+- Added error highlighting (#18)
 
-[Changelog](https://github.com/inmanta/vscode-inmanta/CHANGELOG.md)
-
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
-## [0.0.1]
+# v 0.0.1
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v 0.3.5 (?)
+# v 1.0.0 (?)
 Changes in this release:
 - Added error highlighting (#18)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "inmanta",
-  "version": "0.3.5",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inmanta",
   "displayName": "inmanta",
   "description": "Inmanta",
-  "version": "0.3.5",
+  "version": "1.0.0",
   "publisher": "Inmanta",
   "icon": "images/inmanta.ico",
   "license": "Apache-2.0",

--- a/server/.bumpversion.cfg
+++ b/server/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 1.0.0
+tag = False
+commit = False
+
+[bumpversion:file:setup.py]

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,12 +1,10 @@
-# Change Log
+# v 0.2.1 (?)
+Changes in this release:
+- Added language server to client diagnostics notifications to highlight errors (#18)
 
-[Changelog](https://github.com/inmanta/vscode-inmanta/server/CHANGELOG.md)
+# v 0.2.0
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
-## [0.3.3]
-
-### Engineering
+## Engineering
 * Use native coroutines instead of tornado decorators
 * Made pep8 compatible
 * Added basic smoke test

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v 0.2.2 (?)
+# v 1.0.0 (?)
 Changes in this release:
 - Added language server to client diagnostics notifications to highlight errors (#18)
 

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,8 +1,8 @@
-# v 0.2.1 (?)
+# v 0.2.2 (?)
 Changes in this release:
 - Added language server to client diagnostics notifications to highlight errors (#18)
 
-# v 0.2.0
+# v 0.2.1 (2019-10-31)
 
 ## Engineering
 * Use native coroutines instead of tornado decorators

--- a/server/setup.py
+++ b/server/setup.py
@@ -17,8 +17,8 @@ setup(
     package_dir={"" : "src"},
     packages=find_packages("src"),
     install_requires=requires,
-    
-    version="0.2.1",
+
+    version="0.2.2",
 
     description="Inmanta Language Server",
     long_description=long_description,
@@ -28,14 +28,14 @@ setup(
     license="Apache Software License",
     url="https://github.com/inmanta/vscode-inmanta",
     keywords=["ide","language-server","vscode", "inmanta"],
-    classifiers=["Development Status :: 3 - Alpha", 
+    classifiers=["Development Status :: 3 - Alpha",
                  "Intended Audience :: Developers",
                  "Intended Audience :: Telecommunications Industry",
                  "License :: OSI Approved :: Apache Software License",
                  "Operating System :: OS Independent",
                  "Topic :: System :: Systems Administration",
                  "Topic :: Utilities"],
-    
+
     entry_points={
     'console_scripts': [
         'inmanta-language-server-tcp = inmantals.tcpserver:main',

--- a/server/setup.py
+++ b/server/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages("src"),
     install_requires=requires,
 
-    version="0.2.2",
+    version="1.0.0",
 
     description="Inmanta Language Server",
     long_description=long_description,
@@ -28,7 +28,7 @@ setup(
     license="Apache Software License",
     url="https://github.com/inmanta/vscode-inmanta",
     keywords=["ide","language-server","vscode", "inmanta"],
-    classifiers=["Development Status :: 3 - Alpha",
+    classifiers=["Development Status :: 5 - Stable",
                  "Intended Audience :: Developers",
                  "Intended Audience :: Telecommunications Industry",
                  "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
### Changes to server changelog
- changelog now conforms to the inmanta-tools format
- current version added
- previous version was listed as 0.3.3 but `setup.py` was at 0.2.0 at the time of those changes.

### Changes to client changelog
- changelog now conforms to the inmanta-tools format
- current version added