### PR TITLE
updated convert_location to mark whole line

### DIFF
--- a/server/src/inmantals/server.py
+++ b/server/src/inmantals/server.py
@@ -230,7 +230,7 @@ class InmantaLSHandler(JsonRpcHandler):
                 "uri": "file://" + loc.file,
                 "range": {
                     "start": {"line": loc.lnr - 1, "character": 0},
-                    "end": {"line": loc.lnr - 1, "character": 0},
+                    "end": {"line": loc.lnr, "character": 0},
                 },
             }
 

--- a/server/tests/test_smoke.py
+++ b/server/tests/test_smoke.py
@@ -297,7 +297,7 @@ async def test_symbol_provider(client: JsonRPC) -> None:
             location=lsp_types.Location(
                 uri=uri_testmodule_model,
                 range=lsp_types.Range(
-                    start=lsp_types.Position(line=1, character=0), end=lsp_types.Position(line=1, character=0)
+                    start=lsp_types.Position(line=1, character=0), end=lsp_types.Position(line=2, character=0)
                 ),
             ),
             container_name="testmodule::SymbolTest",


### PR DESCRIPTION
This PR updates `convert_location` to mark the whole line when it receives a plain `inmanta.ast.Location` instance. This results in vscode underlining the whole line instead of only the first character (usually a space in the case of an attribute declaration) to indicate an error. This is related to inmanta/inmanta#2481.

From [the LSP spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#range): "If you want to specify a range that contains a line including the line ending character(s) then use an end position denoting the start of the next line."