### PR TITLE
updated test case to be compatible with both pre- and post 2020.6 location info

### DIFF
--- a/server/tests/test_smoke.py
+++ b/server/tests/test_smoke.py
@@ -1,16 +1,23 @@
 import json
 import logging
 import socket
-from typing import AsyncIterator, Dict, List, Optional
+from typing import AsyncIterator, Dict, List, Optional, Union
 
 import pytest
 import os
+import pkg_resources
+import packaging.version
 
 from tornado.iostream import IOStream
 from inmantals import lsp_types
 from inmantals.jsonrpc import JsonRpcServer
 from inmantals.server import InmantaLSHandler
 from tornado.tcpclient import TCPClient
+
+
+INMANTA_VERSION: Union[packaging.version.Version, packaging.version.LegacyVersion] = packaging.version.parse(
+    pkg_resources.get_distribution("inmanta").version
+)
 
 
 class JsonRPC(object):
@@ -127,7 +134,7 @@ async def assert_lnr_reverse(client):
         "textDocument/references",
         textDocument={"uri": f"file://{path}/main.cf"},
         position={"line": 0, "character": 8},
-        context={}
+        context={},
     )
     result = await client.assert_one(ret)
     assert result == [{
@@ -158,7 +165,7 @@ async def test_connection(client, caplog):
             },
             "definitionProvider": True,
             "referencesProvider": True,
-            "workspaceSymbolProvider": {"workDoneProgress": False}
+            "workspaceSymbolProvider": {"workDoneProgress": False},
         }
     }
 
@@ -250,6 +257,8 @@ async def test_symbol_provider(client: JsonRPC) -> None:
     uri_testmodule_model: str = "file://%s" % os.path.join(testmodule_dir, "model", "_init.cf")
     uri_testmodule_plugins: str = "file://%s" % os.path.join(testmodule_dir, "plugins", "__init__.py")
 
+    improved_locations: bool = INMANTA_VERSION >= packaging.version.parse("2020.6.dev")
+
     assert symbol_info == [
         lsp_types.SymbolInformation(
             name="__config__::my_symbol_test_type",
@@ -286,8 +295,14 @@ async def test_symbol_provider(client: JsonRPC) -> None:
             kind=lsp_types.SymbolKind.Function,
             location=lsp_types.Location(
                 uri=uri_testmodule_plugins,
-                range=lsp_types.Range(
-                    start=lsp_types.Position(line=4, character=0), end=lsp_types.Position(line=4, character=1)
+                range=(
+                    lsp_types.Range(
+                        start=lsp_types.Position(line=4, character=0), end=lsp_types.Position(line=5, character=0)
+                    )
+                    if improved_locations
+                    else lsp_types.Range(
+                        start=lsp_types.Position(line=4, character=0), end=lsp_types.Position(line=4, character=1)
+                    )
                 ),
             ),
         ),
@@ -296,8 +311,14 @@ async def test_symbol_provider(client: JsonRPC) -> None:
             kind=lsp_types.SymbolKind.Field,
             location=lsp_types.Location(
                 uri=uri_testmodule_model,
-                range=lsp_types.Range(
-                    start=lsp_types.Position(line=1, character=0), end=lsp_types.Position(line=2, character=0)
+                range=(
+                    lsp_types.Range(
+                        start=lsp_types.Position(line=1, character=11), end=lsp_types.Position(line=1, character=17)
+                    )
+                    if improved_locations
+                    else lsp_types.Range(
+                        start=lsp_types.Position(line=1, character=0), end=lsp_types.Position(line=2, character=0)
+                    )
                 ),
             ),
             container_name="testmodule::SymbolTest",


### PR DESCRIPTION
Required because of inmanta/inmanta#2488 and inmanta/inmanta#2489.