### PR TITLE
fixed release pipeline issue related to npm install artifacts

### DIFF
--- a/.ci/Jenkinsfile-extension-vsce
+++ b/.ci/Jenkinsfile-extension-vsce
@@ -44,6 +44,9 @@ pipeline {
                             echo 'echo \${GITHUB_TOKEN}' > ${GIT_ASKPASS}
                             chmod u+x ${GIT_ASKPASS}
 
+                            # install the extension for its vsce dependency, required for building and publishing the extension
+                            npm ci
+
                             # checkout appropriate branch
                             if [ "${version_increment}" == "none" ] || [ "${version_increment}" == "patch" ]; then
                                 git checkout next
@@ -159,17 +162,6 @@ pipeline {
             }
         }
 
-        stage("Install vsce") {
-            when {
-                expression { "${run_job}" == "true" }
-            }
-            steps {
-                dir('vscode-inmanta') {
-                    sh 'npm install vsce'
-                }
-            }
-        }
-
         stage("Build") {
             when {
                 expression { "${run_job}" == "true" }
@@ -194,17 +186,6 @@ pipeline {
                     withCredentials([string(credentialsId: 'vscode_marketplace_access_token', variable: 'VSCODE_PERSONAL_ACCESS_TOKEN')]) {
                         sh '$(npm bin)/vsce publish -p "${VSCODE_PERSONAL_ACCESS_TOKEN}"'
                     }
-                }
-            }
-        }
-
-        stage("Clean up npm artifacts") {
-            when {
-                expression { "${run_job}" == "true" }
-            }
-            steps {
-                dir('vscode-inmanta') {
-                    sh 'git checkout package{,-lock}.json'
                 }
             }
         }

--- a/.ci/Jenkinsfile-extension-vsce
+++ b/.ci/Jenkinsfile-extension-vsce
@@ -44,9 +44,6 @@ pipeline {
                             echo 'echo \${GITHUB_TOKEN}' > ${GIT_ASKPASS}
                             chmod u+x ${GIT_ASKPASS}
 
-                            # install vsce for building and publishing the extension
-                            npm install vsce
-
                             # checkout appropriate branch
                             if [ "${version_increment}" == "none" ] || [ "${version_increment}" == "patch" ]; then
                                 git checkout next
@@ -162,6 +159,17 @@ pipeline {
             }
         }
 
+        stage("Install vsce") {
+            when {
+                expression { "${run_job}" == "true" }
+            }
+            steps {
+                dir('vscode-inmanta') {
+                    sh 'npm install vsce'
+                }
+            }
+        }
+
         stage("Build") {
             when {
                 expression { "${run_job}" == "true" }
@@ -186,6 +194,17 @@ pipeline {
                     withCredentials([string(credentialsId: 'vscode_marketplace_access_token', variable: 'VSCODE_PERSONAL_ACCESS_TOKEN')]) {
                         sh '$(npm bin)/vsce publish -p "${VSCODE_PERSONAL_ACCESS_TOKEN}"'
                     }
+                }
+            }
+        }
+
+        stage("Clean up npm artifacts") {
+            when {
+                expression { "${run_job}" == "true" }
+            }
+            steps {
+                dir('vscode-inmanta') {
+                    sh 'git checkout package{,-lock}.json'
                 }
             }
         }


### PR DESCRIPTION
Installing vsce would update `package.json` and `package-lock.json`. This would cause issues with the checkout commands following it. Simply forcing checkout (cleaning up the changes) would cause problems when running `vsce`.