### PR TITLE
Fix pep8 violation problem

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 128
+target-version = ['py36', 'py37', 'py38']

--- a/server/requirement.txt
+++ b/server/requirement.txt
@@ -1,5 +1,0 @@
-inmanta-core
-intervaltree
-pytest
-pytest-asyncio
-pylspclient

--- a/server/requirements.dev.txt
+++ b/server/requirements.dev.txt
@@ -1,0 +1,1 @@
+inmanta-dev-dependencies[async]==1.44.0

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,2 @@
+inmanta-core
+intervaltree==3.1.0

--- a/server/setup.cfg
+++ b/server/setup.cfg
@@ -1,7 +1,6 @@
 [metadata]
 description-file = README.md
 
-
 [flake8]
 # H101 Include your name with TODOs as in # TODO(yourname). This makes it easier to find out who the author of the comment was.
 # H302 Do not import objects, only modules DEPRICATED
@@ -18,4 +17,20 @@ description-file = README.md
 # E203 whitespaces and the slice operator. black and flake disagree
 ignore = H405,H404,H302,H306,H301,H101,H801,E402,W503,E252,E203
 max-line-length = 128
-exclude = **/.env,.venv,.git,.tox,dist,tests/project*/**
+exclude = **/.env,.venv,.git,.tox,dist,tests/project*/**,**egg
+copyright-check=True
+# C errors are not selected by default, so add them to your selection
+select = E,F,W,C,BLK,I
+copyright-author=Inmanta
+
+[isort]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=128
+default_section=FIRSTPARTY
+# When tox runs isort it does not label all 1st and 3rd party packages correct, this causes a difference in sorting between
+# normal and tox. This list forces these packages
+known_first_party=inmanta
+known_third_party=pytest,tornado

--- a/server/setup.py
+++ b/server/setup.py
@@ -1,4 +1,20 @@
+"""
+    Copyright 2021 Inmanta
 
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 from setuptools import setup, find_packages
 from os import path
 
@@ -14,7 +30,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name="inmantals",
-    package_dir={"" : "src"},
+    package_dir={"": "src"},
     packages=find_packages("src"),
     install_requires=requires,
 
@@ -27,7 +43,7 @@ setup(
     author_email="code@inmanta.com",
     license="Apache Software License",
     url="https://github.com/inmanta/vscode-inmanta",
-    keywords=["ide","language-server","vscode", "inmanta"],
+    keywords=["ide", "language-server", "vscode", "inmanta"],
     classifiers=["Development Status :: 5 - Production/Stable",
                  "Intended Audience :: Developers",
                  "Intended Audience :: Telecommunications Industry",
@@ -37,8 +53,8 @@ setup(
                  "Topic :: Utilities"],
 
     entry_points={
-    'console_scripts': [
-        'inmanta-language-server-tcp = inmantals.tcpserver:main',
-    ],
-},
+        'console_scripts': [
+            'inmanta-language-server-tcp = inmantals.tcpserver:main',
+        ],
+    },
 )

--- a/server/src/inmantals/jsonrpc.py
+++ b/server/src/inmantals/jsonrpc.py
@@ -37,8 +37,8 @@ def generate_safe_log_file():
     if file_name is not None:
         return file_name
 
-    import time
     import tempfile
+    import time
 
     file_name = "vscode-inmanta-%08x.log" % round(time.time() * 1000000)
     while os.path.exists(os.path.join(tempfile.gettempdir(), file_name)):
@@ -149,8 +149,7 @@ class JsonRpcHandler(object):
             raise InvalidRequestException("header %s not found" % field, id)
         if value is not None and message[field] != value:
             raise InvalidRequestException(
-                "expected header %s to be %s but was %s"
-                % (field, value, message[field]),
+                "expected header %s to be %s but was %s" % (field, value, message[field]),
                 id,
             )
         return message[field]
@@ -259,9 +258,7 @@ class JsonRpcHandler(object):
                     e.id = id
                     raise
             except Exception as e:
-                logger.debug(
-                    "exception occurred during method handling ", exc_info=True
-                )
+                logger.debug("exception occurred during method handling ", exc_info=True)
                 if id is not None:
                     # no exceptions on notifications
                     raise InternalErrorException(str(e), id)

--- a/server/src/inmantals/lsp_types.py
+++ b/server/src/inmantals/lsp_types.py
@@ -33,9 +33,7 @@ class LspModel(BaseModel):
     """
 
     class Config:
-        alias_generator = partial(
-            re.sub, r"_([a-z])", lambda match: match.group(1).upper()
-        )
+        alias_generator = partial(re.sub, r"_([a-z])", lambda match: match.group(1).upper())
         allow_population_by_field_name = True
 
     def dict(self, *args: object, **kwargs: Any) -> Dict[str, object]:

--- a/server/src/inmantals/pipeserver.py
+++ b/server/src/inmantals/pipeserver.py
@@ -19,9 +19,10 @@
 import logging
 import sys
 
-from inmantals.server import InmantaLSHandler
 from tornado.ioloop import IOLoop
 from tornado.iostream import PipeIOStream
+
+from inmantals.server import InmantaLSHandler
 
 logger = logging.getLogger(__name__)
 

--- a/server/src/inmantals/tcpserver.py
+++ b/server/src/inmantals/tcpserver.py
@@ -19,9 +19,10 @@
 import os
 import sys
 
+from tornado.ioloop import IOLoop
+
 from inmantals.jsonrpc import JsonRpcServer
 from inmantals.server import InmantaLSHandler
-from tornado.ioloop import IOLoop
 
 
 def main():

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = pep8,py{36,38}-inm{master,iso4-stable,latest}
 skip_missing_interpreters=True
-requires = 
+requires =
     pip >= 21.0.1
     wheel
 
@@ -13,9 +13,8 @@ basepython=python3.8
 
 [testenv]
 deps=
-    pytest
-    pytest-asyncio
-    pytest-timeout
+    -rrequirements.dev.txt
+    -rrequirements.txt
     inmlatest: inmanta-core
     inmmaster: git+https://github.com/inmanta/inmanta-core.git
     inmiso4-stable: git+https://github.com/inmanta/inmanta-core.git@iso4-stable
@@ -23,8 +22,5 @@ commands=py.test --junitxml=junit-{envname}.xml -vvv tests/
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT
 
 [testenv:pep8]
-deps=
-    flake8
-    pep8-naming
 commands = flake8 src tests
 basepython = python3


### PR DESCRIPTION
This PR applies the following changes:

* The pep8 check failed without any changes to the source code, because the language server didn't pin its dependencies in the `requirements.txt` and the `requirements.dev.txt`. This PR add these constraints and makes sure the constraint files are used by the tox configuration.
* Black and isort were fighting with each other, because the setup.cfg file didn't set the black and isort configuration to make them consistent. This PR adds that configuration. It seems that black doesn't read its configuration from the `setup.cfg` anymore, but only from the `pyproject.toml`. That's why the black configuration is stored in the `pyproject.toml` file. This may be an issue on other projects as well.
* The copyright header check was enabled on the project.