### PR TITLE
Fix hanging test loadExtension

### DIFF
--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -15,7 +15,6 @@ pipeline {
       INMANTA_LS_TEST_ENV="${env.WORKSPACE}/ls-venv"
       INMANTA_LS_PATH="${env.WORKSPACE}/server"
       INMANTA_LS_LOG_PATH="${env.WORKSPACE}/server.log"
-      INMANTA_EXTENSION_TEST_ENV="${env.WORKSPACE}/extension-venv"
       PIP_INDEX_URL="https://artifacts.internal.inmanta.com/inmanta/dev"
     }
 

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -3,6 +3,7 @@ pipeline {
 
     options{
         disableConcurrentBuilds()
+        timeout(time: 30, unit: 'MINUTES')
     }
 
     triggers {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,7 @@ export async function activate(context: ExtensionContext) {
 
 		const options: cp.SpawnOptionsWithoutStdio = {};
 		if (process.env.INMANTA_LS_LOG_PATH) {
-			log(`Language Server log file has been manually set to "${process.env.INMANTA_LS_LOG_PATH}"`)
+			log(`Language Server log file has been manually set to "${process.env.INMANTA_LS_LOG_PATH}"`);
 			options.env = {
 				"LOG_PATH": process.env.INMANTA_LS_LOG_PATH  // eslint-disable-line @typescript-eslint/naming-convention
 			};
@@ -239,7 +239,7 @@ export async function activate(context: ExtensionContext) {
 		};
 
 		if (process.env.INMANTA_LS_LOG_PATH) {
-			log(`Language Server log file has been manually set to "${process.env.INMANTA_LS_LOG_PATH}"`)
+			log(`Language Server log file has been manually set to "${process.env.INMANTA_LS_LOG_PATH}"`);
 			serverOptions.options.env["LOG_PATH"] = process.env.INMANTA_LS_LOG_PATH;
 		}
 

--- a/src/test/loadExtension/loadExtension.test.ts
+++ b/src/test/loadExtension/loadExtension.test.ts
@@ -9,16 +9,16 @@ const cfFile: Uri = Uri.file(path.resolve(__dirname, '../../../src/test/compile/
 describe('Load extension', () => {
 
     beforeEach(async function() {
-        await commands.executeCommand('workbench.action.closeFolder');
+        await commands.executeCommand('workbench.action.closeActiveEditor');
     });
 
-    it('Load .cf file wihtout opening a directory NO compilerVenv configured', async function() {
+    it('Load .cf file without opening a directory NO compilerVenv configured', async function() {
         await workspace.getConfiguration('inmanta').update('compilerVenv', "", true);
         // Verify initial state
         assert.ok(!extensions.getExtension('inmanta.inmanta').isActive);
 
         // Open a single file instead of a folder
-        await commands.executeCommand('vscode.open', cfFile);
+        await commands.executeCommand('vscode.open', cfFile)
         const doc: TextDocument = await workspace.openTextDocument(cfFile);
         const edit: TextEditor = await window.showTextDocument(doc);
 

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -9,26 +9,6 @@ async function main() {
 
 	const tmpHomeDir: string = fs.mkdtempSync("/tmp/vscode-tests");
 	try {
-		const settings = {
-			"inmanta.ls.enabled": true,
-		};
-
-		if (process.env.INMANTA_PYTHON_PATH) {
-			settings["inmanta.pythonPath"] = process.env.INMANTA_PYTHON_PATH;
-		}
-
-		if (process.env.INMANTA_COMPILER_VENV) {
-			settings["inmanta.compilerVenv"] = process.env.INMANTA_COMPILER_VENV;
-		}
-
-		// Saving settings of testing workspace to file
-		const workspaceSettingsPath = path.resolve(__dirname, '../../src/test/compile/workspace/.vscode/settings.json');
-		await fs.ensureFile(workspaceSettingsPath);
-		await fs.writeJSON(workspaceSettingsPath, settings);
-		const navworkspaceSettingsPath = path.resolve(__dirname, '../../src/test/navigation/workspace/.vscode/settings.json');
-		await fs.ensureFile(navworkspaceSettingsPath);
-		await fs.writeJSON(navworkspaceSettingsPath, settings);
-
 		// The folder containing the Extension Manifest package.json
 		// Passed to `--extensionDevelopmentPath`
 		const extensionDevelopmentPath = path.resolve(__dirname, '../../');
@@ -43,18 +23,19 @@ async function main() {
 		await runTests({
 			extensionDevelopmentPath: extensionDevelopmentPath,
 			extensionTestsPath: path.resolve(__dirname, './compile/index'),
-			launchArgs: [path.resolve(__dirname, '../../src/test/compile/workspace')],
+			launchArgs: [path.resolve(__dirname, '../../src/test/compile/workspace'), "--disable-gpu"],
 			extensionTestsEnv
 		});
 		await runTests({
 			extensionDevelopmentPath: extensionDevelopmentPath,
 			extensionTestsPath: path.resolve(__dirname, './loadExtension/index'),
+			launchArgs: ["--disable-gpu"],
 			extensionTestsEnv
 		});
 		await runTests({ 
 			extensionDevelopmentPath: extensionDevelopmentPath, 
 			extensionTestsPath: path.resolve(__dirname, './navigation/index'),
-			launchArgs: [path.resolve(__dirname, '../../src/test/navigation/workspace')],
+			launchArgs: [path.resolve(__dirname, '../../src/test/navigation/workspace'), "--disable-gpu"],
 			extensionTestsEnv
 		});
 		

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -10,11 +10,7 @@ async function main() {
 	const tmpHomeDir: string = fs.mkdtempSync("/tmp/vscode-tests");
 	try {
 		const settings = {
-			"inmanta": {
-				"ls": {
-					"enabled": true,
-				}
-			}
+			"inmanta.ls.enabled": true,
 		};
 
 		// Saving settings of testing workspace to file

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -9,6 +9,22 @@ async function main() {
 
 	const tmpHomeDir: string = fs.mkdtempSync("/tmp/vscode-tests");
 	try {
+		const settings = {
+			"inmanta": {
+				"ls": {
+					"enabled": true,
+				}
+			}
+		};
+
+		// Saving settings of testing workspace to file
+		const workspaceSettingsPath = path.resolve(__dirname, '../../src/test/compile/workspace/.vscode/settings.json');
+		await fs.ensureFile(workspaceSettingsPath);
+		await fs.writeJSON(workspaceSettingsPath, settings);
+		const navworkspaceSettingsPath = path.resolve(__dirname, '../../src/test/navigation/workspace/.vscode/settings.json');
+		await fs.ensureFile(navworkspaceSettingsPath);
+		await fs.writeJSON(navworkspaceSettingsPath, settings);
+
 		// The folder containing the Extension Manifest package.json
 		// Passed to `--extensionDevelopmentPath`
 		const extensionDevelopmentPath = path.resolve(__dirname, '../../');


### PR DESCRIPTION
This PR fixes the following issues:

* Make sure that the `LoadExtensions` test doesn't hang anymore
* Fix some styling issues
* Remove redundant code that configures the `settings.json` file on a test project
* Add the `--disable-gpu` flag to reduce the number of CPU-related error/warning in the log. 