### PR TITLE
only run relevant test cases on dependabot branches

### DIFF
--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -1,3 +1,7 @@
+boolean onDependabotBranch(String ecosystem) {
+    return env.BRANCH_NAME ==~ /dependabot\/${ecosystem}\/.*/
+}
+
 pipeline {
     agent any
 
@@ -21,6 +25,9 @@ pipeline {
 
     stages {
         stage('Language server tests') {
+            when {
+                expression { ! onDependabotBranch("npm_and_yarn") }
+            }
             steps {
                 sh '''
                     rm -rf $INMANTA_LS_TEST_ENV
@@ -45,7 +52,7 @@ pipeline {
 
     post {
         always {
-            junit 'server/junit*.xml'
+            junit allowEmptyResults: true, testResults: 'server/junit*.xml'
             deleteDir()
         }
     }


### PR DESCRIPTION
The vscode repo has a Python and a TypeScript part. When dependabot bumps a version for the ts part, the Python part doesn't necessarily need to be tested. Disabling it decreases test time when manual intervention is required.