### PR TITLE
Fix Issue/3080: remove compilerVenv from tests

### DIFF
--- a/src/test/compile/compile.test.ts
+++ b/src/test/compile/compile.test.ts
@@ -26,7 +26,7 @@ describe('Compile checks', () => {
 			fs.remove(libsPath),
 			fs.remove(modelUri.fsPath),
 			]);
-		commands.executeCommand('workbench.action.closeActiveEditor');
+		await commands.executeCommand('workbench.action.closeActiveEditor');
 	});
 
 	tests.forEach(test => {
@@ -35,8 +35,8 @@ describe('Compile checks', () => {
 			const source: string = path.resolve(workspaceUri.fsPath, test.source);
 			await fs.copyFile(source, modelUri.fsPath);
 
-			// Wait one second to let vscode notice we closed the previous editor
-			await new Promise(resolve => setTimeout(() => resolve(true), 1000));
+			// Wait three second to let vscode notice we closed the previous editor
+			await new Promise(resolve => setTimeout(() => resolve(true), 3000));
 
 			// Opening model file
 			const doc: TextDocument = await workspace.openTextDocument(modelUri);
@@ -55,9 +55,6 @@ describe('Compile checks', () => {
 			const libsExists = fs.pathExistsSync(libsPath);
 			assert.strictEqual(libsExists, true, "The libs folder hasn't been created");
 
-			envPath = workspace.getConfiguration('inmanta').get<string>('compilerVenv');
-			const envExists = fs.pathExistsSync(envPath);
-			assert.strictEqual(envExists, true, `The venv folder (${envPath}) hasn't been created`);
 		}).timeout(0);
 	});
 

--- a/src/test/navigation/navigation.test.ts
+++ b/src/test/navigation/navigation.test.ts
@@ -14,8 +14,8 @@ const modelUri: Uri = Uri.file(path.resolve(workspaceUri.fsPath, 'main.cf'));
 
 describe('Language Server Code navigation', () => {
 
-	beforeEach(() => {
-		commands.executeCommand('workbench.action.closeActiveEditor');
+	beforeEach(async () => {
+		await commands.executeCommand('workbench.action.closeActiveEditor');
 	});
 
 	it(`Check that code navigation works`, () => {


### PR DESCRIPTION
fixes issues introduced by PR https://github.com/inmanta/vscode-inmanta/pull/374

1. The compilerVenv is not longer used by the compile test. Everything will be done in the active env.
2. Increased the wait-time in the compile test as sometimes in was not enough.
