### PR TITLE
fix missing dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "get-port": "^5.1.1",
+                "log-symbols": "^4.1.0",
+                "lru-cache": "^6.0.0",
+                "minimatch": "^3.0.4",
                 "vscode-languageclient": "^7.0.0"
             },
             "devDependencies": {
@@ -34,7 +37,7 @@
                 "vsce": "^2.6.6"
             },
             "engines": {
-                "vscode": "^1.50.0"
+                "vscode": "^1.63.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -471,7 +474,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -757,7 +759,6 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -826,6 +827,7 @@
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
+                "fsevents": "~2.3.2",
                 "glob-parent": "~5.1.2",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -904,7 +906,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -915,8 +916,7 @@
         "node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "node_modules/commander": {
             "version": "6.2.1",
@@ -1016,15 +1016,18 @@
             }
         },
         "node_modules/decompress-response": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-            "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
             "dev": true,
             "dependencies": {
-                "mimic-response": "^2.0.0"
+                "mimic-response": "^3.1.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/deep-extend": {
@@ -1049,15 +1052,12 @@
             "dev": true
         },
         "node_modules/detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.0.tgz",
+            "integrity": "sha512-S55LzUl8HUav8l9E2PBTlC5PAJrHK7tkM+XXFGD+fbsbkTzhCpG6K05LxJcUOEWzMa4v6ptcMZ9s3fOdJDu0Zw==",
             "dev": true,
-            "bin": {
-                "detect-libc": "bin/detect-libc.js"
-            },
             "engines": {
-                "node": ">=0.10"
+                "node": ">=8"
             }
         },
         "node_modules/diff": {
@@ -1806,7 +1806,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2039,7 +2038,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
             "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -2089,6 +2087,7 @@
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
             "dependencies": {
+                "graceful-fs": "^4.1.6",
                 "universalify": "^2.0.0"
             },
             "optionalDependencies": {
@@ -2096,14 +2095,14 @@
             }
         },
         "node_modules/keytar": {
-            "version": "7.7.0",
-            "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.7.0.tgz",
-            "integrity": "sha512-YEY9HWqThQc5q5xbXbRwsZTh2PJ36OSYRjSv3NN2xf5s5dpLTjEZnC2YikR29OaVybf9nQ0dJ/80i40RS97t/A==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.8.0.tgz",
+            "integrity": "sha512-mR+BqtAOIW8j+T5FtLVyckCbvROWQD+4FzPeFMuk5njEZkXLpVPCGF26Y3mTyxMAAL1XCfswR7S6kIf+THSRFA==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "node-addon-api": "^3.0.0",
-                "prebuild-install": "^6.0.0"
+                "node-addon-api": "^4.3.0",
+                "prebuild-install": "^7.0.1"
             }
         },
         "node_modules/leven": {
@@ -2168,7 +2167,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
             "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-            "dev": true,
             "dependencies": {
                 "chalk": "^4.1.0",
                 "is-unicode-supported": "^0.1.0"
@@ -2257,12 +2255,12 @@
             }
         },
         "node_modules/mimic-response": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-            "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
             "dev": true,
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -2404,27 +2402,21 @@
             "dev": true
         },
         "node_modules/node-abi": {
-            "version": "2.30.1",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-            "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.7.0.tgz",
+            "integrity": "sha512-3J+U4CvxVNEk9+lGdJkmYbN8cIN0HMTDT9R0ezX7pmp7aD6BaKsfAHwVn3IvVg6pYIRUuQ+gHW1eawrvywnSQQ==",
             "dev": true,
             "dependencies": {
-                "semver": "^5.4.1"
-            }
-        },
-        "node_modules/node-abi/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver"
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/node-addon-api": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-            "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+            "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
             "dev": true
         },
         "node_modules/normalize-path": {
@@ -2643,22 +2635,22 @@
             }
         },
         "node_modules/prebuild-install": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
-            "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.1.tgz",
+            "integrity": "sha512-QBSab31WqkyxpnMWQxubYAHR5S9B2+r81ucocew34Fkl98FhvKIF50jIJnNOBmAZfyNV7vE5T6gd3hTVWgY6tg==",
             "dev": true,
             "dependencies": {
-                "detect-libc": "^1.0.3",
+                "detect-libc": "^2.0.0",
                 "expand-template": "^2.0.3",
                 "github-from-package": "0.0.0",
                 "minimist": "^1.2.3",
                 "mkdirp-classic": "^0.5.3",
                 "napi-build-utils": "^1.0.1",
-                "node-abi": "^2.21.0",
+                "node-abi": "^3.3.0",
                 "npmlog": "^4.0.1",
                 "pump": "^3.0.0",
                 "rc": "^1.2.7",
-                "simple-get": "^3.0.3",
+                "simple-get": "^4.0.0",
                 "tar-fs": "^2.0.0",
                 "tunnel-agent": "^0.6.0"
             },
@@ -2666,7 +2658,7 @@
                 "prebuild-install": "bin.js"
             },
             "engines": {
-                "node": ">=6"
+                "node": ">=10"
             }
         },
         "node_modules/prelude-ls": {
@@ -3017,12 +3009,26 @@
             ]
         },
         "node_modules/simple-get": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-            "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
             "dependencies": {
-                "decompress-response": "^4.2.0",
+                "decompress-response": "^6.0.0",
                 "once": "^1.3.1",
                 "simple-concat": "^1.0.0"
             }
@@ -3114,7 +3120,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -4030,7 +4035,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "requires": {
                 "color-convert": "^2.0.1"
             }
@@ -4239,7 +4243,6 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4354,7 +4357,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "requires": {
                 "color-name": "~1.1.4"
             }
@@ -4362,8 +4364,7 @@
         "color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "commander": {
             "version": "6.2.1",
@@ -4434,12 +4435,12 @@
             "dev": true
         },
         "decompress-response": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-            "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
             "dev": true,
             "requires": {
-                "mimic-response": "^2.0.0"
+                "mimic-response": "^3.1.0"
             }
         },
         "deep-extend": {
@@ -4461,9 +4462,9 @@
             "dev": true
         },
         "detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.0.tgz",
+            "integrity": "sha512-S55LzUl8HUav8l9E2PBTlC5PAJrHK7tkM+XXFGD+fbsbkTzhCpG6K05LxJcUOEWzMa4v6ptcMZ9s3fOdJDu0Zw==",
             "dev": true
         },
         "diff": {
@@ -5039,8 +5040,7 @@
         "has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "has-symbols": {
             "version": "1.0.2",
@@ -5200,8 +5200,7 @@
         "is-unicode-supported": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-            "dev": true
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
         },
         "isarray": {
             "version": "1.0.0",
@@ -5247,13 +5246,13 @@
             }
         },
         "keytar": {
-            "version": "7.7.0",
-            "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.7.0.tgz",
-            "integrity": "sha512-YEY9HWqThQc5q5xbXbRwsZTh2PJ36OSYRjSv3NN2xf5s5dpLTjEZnC2YikR29OaVybf9nQ0dJ/80i40RS97t/A==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.8.0.tgz",
+            "integrity": "sha512-mR+BqtAOIW8j+T5FtLVyckCbvROWQD+4FzPeFMuk5njEZkXLpVPCGF26Y3mTyxMAAL1XCfswR7S6kIf+THSRFA==",
             "dev": true,
             "requires": {
-                "node-addon-api": "^3.0.0",
-                "prebuild-install": "^6.0.0"
+                "node-addon-api": "^4.3.0",
+                "prebuild-install": "^7.0.1"
             }
         },
         "leven": {
@@ -5306,7 +5305,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
             "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-            "dev": true,
             "requires": {
                 "chalk": "^4.1.0",
                 "is-unicode-supported": "^0.1.0"
@@ -5370,9 +5368,9 @@
             "dev": true
         },
         "mimic-response": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-            "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
             "dev": true
         },
         "minimatch": {
@@ -5484,26 +5482,18 @@
             "dev": true
         },
         "node-abi": {
-            "version": "2.30.1",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-            "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.7.0.tgz",
+            "integrity": "sha512-3J+U4CvxVNEk9+lGdJkmYbN8cIN0HMTDT9R0ezX7pmp7aD6BaKsfAHwVn3IvVg6pYIRUuQ+gHW1eawrvywnSQQ==",
             "dev": true,
             "requires": {
-                "semver": "^5.4.1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "dev": true
-                }
+                "semver": "^7.3.5"
             }
         },
         "node-addon-api": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-            "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+            "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
             "dev": true
         },
         "normalize-path": {
@@ -5670,22 +5660,22 @@
             "dev": true
         },
         "prebuild-install": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
-            "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.1.tgz",
+            "integrity": "sha512-QBSab31WqkyxpnMWQxubYAHR5S9B2+r81ucocew34Fkl98FhvKIF50jIJnNOBmAZfyNV7vE5T6gd3hTVWgY6tg==",
             "dev": true,
             "requires": {
-                "detect-libc": "^1.0.3",
+                "detect-libc": "^2.0.0",
                 "expand-template": "^2.0.3",
                 "github-from-package": "0.0.0",
                 "minimist": "^1.2.3",
                 "mkdirp-classic": "^0.5.3",
                 "napi-build-utils": "^1.0.1",
-                "node-abi": "^2.21.0",
+                "node-abi": "^3.3.0",
                 "npmlog": "^4.0.1",
                 "pump": "^3.0.0",
                 "rc": "^1.2.7",
-                "simple-get": "^3.0.3",
+                "simple-get": "^4.0.0",
                 "tar-fs": "^2.0.0",
                 "tunnel-agent": "^0.6.0"
             }
@@ -5925,12 +5915,12 @@
             "dev": true
         },
         "simple-get": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-            "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
             "dev": true,
             "requires": {
-                "decompress-response": "^4.2.0",
+                "decompress-response": "^6.0.0",
                 "once": "^1.3.1",
                 "simple-concat": "^1.0.0"
             }
@@ -6005,7 +5995,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
             "requires": {
                 "has-flag": "^4.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "syntax"
     ],
     "engines": {
-        "vscode": "^1.50.0"
+        "vscode": "^1.63.0"
     },
     "categories": [
         "Programming Languages"
@@ -82,6 +82,9 @@
     },
     "dependencies": {
         "get-port": "^5.1.1",
+        "log-symbols": "^4.1.0",
+        "lru-cache": "^6.0.0",
+        "minimatch": "^3.0.4",
         "vscode-languageclient": "^7.0.0"
     },
     "activationEvents": [


### PR DESCRIPTION
When install the extension in vscode the activation fails due to some missing dependencies and dependencies of those dependencies.
- lru-cache(6.0.0):
   - yallist(4.0.0)
- log-symbols(4.1.0)
- minimatch(3.0.4):
   - brace-expansion(1.1.17):
      - balanced-match (1.0.2)
       - concat-map (0.0.1)

This commit fixes the issue by adding the missing dependencies. 

issue #442 