### PR TITLE
publish package that has just been built

### DIFF
--- a/.ci/Jenkinsfile-extension-vsce
+++ b/.ci/Jenkinsfile-extension-vsce
@@ -189,7 +189,7 @@ pipeline {
                 dir('vscode-inmanta') {
                     // This token has a limited lifetime. See the credential's description for more information on how to create a new one.
                     withCredentials([string(credentialsId: 'vscode_marketplace_access_token', variable: 'VSCODE_PERSONAL_ACCESS_TOKEN')]) {
-                        sh '$(npm bin)/vsce publish -p "${VSCODE_PERSONAL_ACCESS_TOKEN}"'
+                        sh '$(npm bin)/vsce publish --packagePath *.vsix -p "${VSCODE_PERSONAL_ACCESS_TOKEN}"'
                     }
                 }
             }


### PR DESCRIPTION
It looks like `vsce publish` does a package and publish, unless given a path to a vsix file. So by cleaning up the working dir after building the package, we lose all required vscodeignore state for the build that counts. This PR instructs the publish command to publish the artifact that was built in the previous stage, rather than build a new one.