### PR TITLE
pinned inmanta-dev-dependencies for 3.6

### DIFF
--- a/server/requirements.dev.txt
+++ b/server/requirements.dev.txt
@@ -1,1 +1,2 @@
-inmanta-dev-dependencies[async]==1.76.0
+inmanta-dev-dependencies[async]==1.76.0; python_version <= '3.6'
+inmanta-dev-dependencies[async]==1.76.0; python_version > '3.6'


### PR DESCRIPTION
I didn't bump the 3.7+ version yet because I want to make sure dependabot manages to pick it up.