### PR TITLE
fixed tox config for iso4

### DIFF
--- a/server/tox.ini
+++ b/server/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py36-inmiso4,py39-inm{master,iso5-stable,latest}
+envlist = pep8,py36-inmiso4-stable,py39-inm{master,iso5-stable,latest}
 skip_missing_interpreters=True
 requires =
     pip >= 21.0.1


### PR DESCRIPTION
The env name for iso4 didn't match the env name used in the `deps` config section. As a result, for iso4 tests, the pip install just used the requirements files without specifying a specific core version. This resulted in the latest core being installed.