### PR TITLE
Issue/84 enable flake8 style checking on inmantals

### DIFF
--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -60,7 +60,8 @@ pipeline {
         stage('Style checking') {
              steps {
                 sh '''
-                    make
+                    make format
+                    make pep8
                 '''
             }
         }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -60,8 +60,8 @@ pipeline {
         stage('Style checking') {
              steps {
                 sh '''
-                    make format
-                    make pep8
+                    pwd
+                    ls
                 '''
             }
         }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -22,7 +22,7 @@ pipeline {
       INMANTA_LS_PATH="${env.WORKSPACE}/server"
       INMANTA_LS_LOG_PATH="${env.WORKSPACE}/server.log"
       PIP_INDEX_URL="https://artifacts.internal.inmanta.com/inmanta/dev"
-      INMANTA_STYLE_CHECK_ENV="./style-check-venv"
+      INMANTA_STYLE_CHECK_ENV="${env.WORKSPACE}/style-check-venv"
     }
 
     stages {
@@ -65,7 +65,6 @@ pipeline {
                         source $INMANTA_STYLE_CHECK_ENV/bin/activate
                         pip install --upgrade pip
                         make pep8
-                        make format
                     '''
                 }
             }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -23,6 +23,7 @@ pipeline {
       INMANTA_LS_LOG_PATH="${env.WORKSPACE}/server.log"
       PIP_INDEX_URL="https://artifacts.internal.inmanta.com/inmanta/dev"
       DIR_TO_LINT="$INMANTA_LS_PATH/src $INMANTA_LS_PATH/tests"
+      INMANTA_STYLE_CHECK_ENV="${env.WORKSPACE}/style-check-venv"
     }
 
     stages {
@@ -59,10 +60,12 @@ pipeline {
         stage('Style checking') {
              steps {
                 sh '''
-                    "python3 -m venv ${env.WORKSPACE}/env"
-                    ""${env.WORKSPACE}/env/bin/pip install -U pip"
-                    ""${env.WORKSPACE}/env/bin/pip install -r requirements.dev.txt"
-                    "$INMANTA_LS_PATH/env/bin/flake8 $DIR_TO_LINT"
+                    "rm -rf $INMANTA_STYLE_CHECK_ENV"
+                    "python3 -m venv $INMANTA_STYLE_CHECK_ENV"
+                    "source $INMANTA_STYLE_CHECK_ENV/bin/activate"
+                    "$INMANTA_STYLE_CHECK_ENV/bin/pip install -U pip"
+                    "$INMANTA_STYLE_CHECK_ENV/bin/pip install -r requirements.dev.txt"
+                    "$INMANTA_STYLE_CHECK_ENV/bin/flake8 $DIR_TO_LINT"
                 '''
             }
         }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -26,15 +26,6 @@ pipeline {
     }
 
     stages {
-        stage('Style checking') {
-             steps {
-                sh '''
-                    "pwd"
-                    "ls"
-                    "$INMANTA_LS_PATH/env/bin/flake8 $DIR_TO_LINT"
-                '''
-            }
-        }
         stage('Language server tests') {
             when {
                 expression { ! onDependabotBranch("npm_and_yarn") }
@@ -62,6 +53,13 @@ pipeline {
                     rm -rf node_modules
                     npm i --also=dev
                     xvfb-run npm run test
+                '''
+            }
+        }
+        stage('Style checking') {
+             steps {
+                sh '''
+                    "$INMANTA_LS_PATH/env/bin/flake8 $DIR_TO_LINT"
                 '''
             }
         }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -60,7 +60,7 @@ pipeline {
         stage('Style checking') {
              steps {
                 sh '''
-                    "rm -rf $INMANTA_STYLE_CHECK_ENV"
+                    "rm -rf $INMANTA_STYLE_CHECK_ENV || true"
                     "python3 -m venv $INMANTA_STYLE_CHECK_ENV"
                     "source $INMANTA_STYLE_CHECK_ENV/bin/activate"
                     "$INMANTA_STYLE_CHECK_ENV/bin/pip install -U pip"

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -25,6 +25,13 @@ pipeline {
     }
 
     stages {
+        stage('Style checking') {
+             steps {
+                sh '''
+                    ${env.WORKSPACE}/env/bin/flake8 src tests
+                '''
+            }
+        }
         stage('Language server tests') {
             when {
                 expression { ! onDependabotBranch("npm_and_yarn") }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -59,9 +59,9 @@ pipeline {
         stage('Style checking') {
              steps {
                 sh '''
-                    python3 -m venv ${env.WORKSPACE}/env
-                    ${WORKSPACE}/env/bin/pip install -U pip
-                    ${WORKSPACE}/env/bin/pip install -r requirements.dev.txt
+                    "python3 -m venv ${env.WORKSPACE}/env"
+                    ""${env.WORKSPACE}/env/bin/pip install -U pip"
+                    ""${env.WORKSPACE}/env/bin/pip install -r requirements.dev.txt"
                     "$INMANTA_LS_PATH/env/bin/flake8 $DIR_TO_LINT"
                 '''
             }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -59,6 +59,7 @@ pipeline {
         stage('Style checking') {
              steps {
                 sh '''
+                    "which flake8"
                     "pwd"
                     "ls"
                     "$INMANTA_LS_PATH/env/bin/flake8 $DIR_TO_LINT"

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -70,8 +70,8 @@ pipeline {
                         python3 -m venv $INMANTA_STYLE_CHECK_ENV
                         source $INMANTA_STYLE_CHECK_ENV/bin/activate
                         pip install --upgrade pip
-                        make format
                         make pep8
+                        make format
                     '''
                 }
             }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -28,7 +28,7 @@ pipeline {
         stage('Style checking') {
              steps {
                 sh '''
-                    ${env.WORKSPACE}/env/bin/flake8 src tests
+                    "$INMANTA_LS_PATH/env/bin/flake8 src tests"
                 '''
             }
         }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -60,11 +60,7 @@ pipeline {
         stage('Style checking') {
              steps {
                 sh '''
-                    "python3 -m venv $INMANTA_STYLE_CHECK_ENV"
-                    "source $INMANTA_STYLE_CHECK_ENV/bin/activate"
-                    "$INMANTA_STYLE_CHECK_ENV/bin/pip install -U pip"
-                    "$INMANTA_STYLE_CHECK_ENV/bin/pip install -r requirements.dev.txt"
-                    "$INMANTA_STYLE_CHECK_ENV/bin/flake8 $DIR_TO_LINT"
+                    make
                 '''
             }
         }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -22,13 +22,14 @@ pipeline {
       INMANTA_LS_PATH="${env.WORKSPACE}/server"
       INMANTA_LS_LOG_PATH="${env.WORKSPACE}/server.log"
       PIP_INDEX_URL="https://artifacts.internal.inmanta.com/inmanta/dev"
+      DIR_TO_LINT="$INMANTA_LS_PATH/src $INMANTA_LS_PATH/tests"
     }
 
     stages {
         stage('Style checking') {
              steps {
                 sh '''
-                    "$INMANTA_LS_PATH/env/bin/flake8 src tests"
+                    "$INMANTA_LS_PATH/env/bin/flake8 $DIR_TO_LINT"
                 '''
             }
         }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -59,9 +59,9 @@ pipeline {
         stage('Style checking') {
              steps {
                 sh '''
-                    "which flake8"
-                    "pwd"
-                    "ls"
+                    python3 -m venv ${env.WORKSPACE}/env
+                    ${WORKSPACE}/env/bin/pip install -U pip
+                    ${WORKSPACE}/env/bin/pip install -r requirements.dev.txt
                     "$INMANTA_LS_PATH/env/bin/flake8 $DIR_TO_LINT"
                 '''
             }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -22,7 +22,6 @@ pipeline {
       INMANTA_LS_PATH="${env.WORKSPACE}/server"
       INMANTA_LS_LOG_PATH="${env.WORKSPACE}/server.log"
       PIP_INDEX_URL="https://artifacts.internal.inmanta.com/inmanta/dev"
-      DIR_TO_LINT="$INMANTA_LS_PATH/src $INMANTA_LS_PATH/tests"
       INMANTA_STYLE_CHECK_ENV="./style-check-venv"
     }
 
@@ -59,14 +58,9 @@ pipeline {
         }
         stage('Style checking') {
              steps {
-                sh '''
-                    pwd
-                    ls
-                    env
-
-                '''
                 dir("server"){
                     sh '''
+                        rm -rf $INMANTA_STYLE_CHECK_ENV
                         python3 -m venv $INMANTA_STYLE_CHECK_ENV
                         source $INMANTA_STYLE_CHECK_ENV/bin/activate
                         pip install --upgrade pip

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -60,7 +60,6 @@ pipeline {
         stage('Style checking') {
              steps {
                 sh '''
-                    "rm -rf $INMANTA_STYLE_CHECK_ENV || true"
                     "python3 -m venv $INMANTA_STYLE_CHECK_ENV"
                     "source $INMANTA_STYLE_CHECK_ENV/bin/activate"
                     "$INMANTA_STYLE_CHECK_ENV/bin/pip install -U pip"

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -23,7 +23,7 @@ pipeline {
       INMANTA_LS_LOG_PATH="${env.WORKSPACE}/server.log"
       PIP_INDEX_URL="https://artifacts.internal.inmanta.com/inmanta/dev"
       DIR_TO_LINT="$INMANTA_LS_PATH/src $INMANTA_LS_PATH/tests"
-      INMANTA_STYLE_CHECK_ENV="${env.WORKSPACE}/style-check-venv"
+      INMANTA_STYLE_CHECK_ENV="./style-check-venv"
     }
 
     stages {
@@ -62,7 +62,18 @@ pipeline {
                 sh '''
                     pwd
                     ls
+                    env
+
                 '''
+                dir("server"){
+                    sh '''
+                        python3 -m venv $INMANTA_STYLE_CHECK_ENV
+                        source $INMANTA_STYLE_CHECK_ENV/bin/activate
+                        pip install --upgrade pip
+                        make format
+                        make pep8
+                    '''
+                }
             }
         }
     }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -29,6 +29,8 @@ pipeline {
         stage('Style checking') {
              steps {
                 sh '''
+                    "pwd"
+                    "ls"
                     "$INMANTA_LS_PATH/env/bin/flake8 $DIR_TO_LINT"
                 '''
             }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -59,6 +59,8 @@ pipeline {
         stage('Style checking') {
              steps {
                 sh '''
+                    "pwd"
+                    "ls"
                     "$INMANTA_LS_PATH/env/bin/flake8 $DIR_TO_LINT"
                 '''
             }

--- a/server/Makefile
+++ b/server/Makefile
@@ -9,5 +9,5 @@ format:
 
 .PHONY: pep8
 pep8:
-	pip install -c requirements.dev.txt pep8-naming flake8-black flake8-isort
+	pip install -r requirements.dev.txt pep8-naming flake8-black flake8-isort
 	flake8 src tests

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,5 +1,4 @@
 # Shortcuts for various dev tasks. Based on makefile from pydantic
-.DEFAULT_GOAL := all
 isort = isort src tests
 black = black src tests
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,0 +1,14 @@
+# Shortcuts for various dev tasks. Based on makefile from pydantic
+.DEFAULT_GOAL := all
+isort = isort src tests
+black = black src tests
+
+.PHONY: format
+format:
+	$(isort)
+	$(black)
+
+.PHONY: pep8
+pep8:
+	pip install -c requirements.txt pep8-naming flake8-black flake8-isort
+	flake8 src tests

--- a/server/Makefile
+++ b/server/Makefile
@@ -9,5 +9,5 @@ format:
 
 .PHONY: pep8
 pep8:
-	pip install -c requirements.txt pep8-naming flake8-black flake8-isort
+	pip install -c requirements.dev.txt pep8-naming flake8-black flake8-isort
 	flake8 src tests


### PR DESCRIPTION
- [ ] Update `setup.cfg` with `flake8` config.
> flake8 config was already present it seems
- [x] Update `.ci/Jenkinsfile-tests` with a style checking stage that runs `flake8` against `src` and `tests`.
- [x] Add `Makefile` with `pep8` and `format` targets.
- [x] Run `make format` to make all existing code comply with the enforced style.

closes #84