### PR TITLE
add ansiColor and update vsce dependency

### DIFF
--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -75,7 +75,6 @@ pipeline {
     post {
         always {
             junit allowEmptyResults: true, testResults: 'server/junit*.xml'
-            archiveArtifacts artifacts: "${env.INMANTA_LS_LOG_PATH}", allowEmptyArchive: true
             deleteDir()
         }
     }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -49,7 +49,7 @@ pipeline {
                     python3 -m venv $INMANTA_EXTENSION_TEST_ENV
                     source $INMANTA_EXTENSION_TEST_ENV/bin/activate
                     pip install --upgrade pip
-                    pip install -e server/
+                    pip install inmantals
                     deactivate
                     rm -rf node_modules
                     npm i --also=dev

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -8,6 +8,7 @@ pipeline {
     options{
         disableConcurrentBuilds()
         timeout(time: 30, unit: 'MINUTES')
+        ansiColor('xterm')
     }
 
     triggers {
@@ -74,6 +75,7 @@ pipeline {
     post {
         always {
             junit allowEmptyResults: true, testResults: 'server/junit*.xml'
+            archiveArtifacts artifacts: "${env.INMANTA_LS_LOG_PATH}", allowEmpty: true
             deleteDir()
         }
     }

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -49,7 +49,7 @@ pipeline {
                     python3 -m venv $INMANTA_EXTENSION_TEST_ENV
                     source $INMANTA_EXTENSION_TEST_ENV/bin/activate
                     pip install --upgrade pip
-                    pip install inmantals
+                    pip install -e server/
                     deactivate
                     rm -rf node_modules
                     npm i --also=dev

--- a/.ci/Jenkinsfile-tests
+++ b/.ci/Jenkinsfile-tests
@@ -75,7 +75,7 @@ pipeline {
     post {
         always {
             junit allowEmptyResults: true, testResults: 'server/junit*.xml'
-            archiveArtifacts artifacts: "${env.INMANTA_LS_LOG_PATH}", allowEmpty: true
+            archiveArtifacts artifacts: "${env.INMANTA_LS_LOG_PATH}", allowEmptyArchive: true
             deleteDir()
         }
     }

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
         "@typescript-eslint/eslint-plugin": "^5.45.1",
         "@typescript-eslint/parser": "^5.45.1",
         "@vscode/test-electron": "^2.2.0",
+        "@vscode/vsce": "^2.15.0",
         "eslint": "^8.29.0",
         "eslint-config-google": "^0.14.0",
         "fs-extra": "^11.1.0",
@@ -121,8 +122,7 @@
         "mocha": "^10.1.0",
         "rimraf": "^3.0.2",
         "semver": "^7.3.8",
-        "typescript": "^4.9.3",
-        "vsce": "^2.15.0"
+        "typescript": "^4.9.3"
     },
     "main": "./out/extension"
 }


### PR DESCRIPTION
These are minor changes I did along the way while debugging the vscode issue. They are completely separate from it.
- use `ansiColor` plugin for better rendering on Jenkins
- renamed `vsce` dependency, see https://code.visualstudio.com/updates/v1_74#_renaming-of-vsce-to-vscodevsce