### PR TITLE
Fix broken tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # v 1.2.0 (?)
 Changes in this release:
 - remove EntityLike as it doesn't exist anymore.
+- Fix bug where two Inmanta language servers would run simultaneously for a short period of time when the language server is restarted.
+- Fix bug where changing to a different venv starts the Inmanta language server, even when it's disabled in the configuration.
+- Fix bug where the Inmanta language server is restarted, even when the configured venv has not changed.
 
 # v 1.1.0 (2022-01-14)
 Changes in this release:

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 1.3.0 (?)
 Changes in this release:
+- Ensure that the language server stops compiling when it receives a shutdown request. This prevents that two language servers are acting on the same project simultaneously.
 
 # v 1.2.0 (2022-01-13)
 Changes in this release:

--- a/server/src/inmantals/jsonrpc.py
+++ b/server/src/inmantals/jsonrpc.py
@@ -127,6 +127,7 @@ class JsonRpcHandler(object):
         self.outstream = outstream
         self.address = address
         self.running = True
+        self.shutdown_requested = False
         self.io_loop = IOLoop.current()
         self.writelock = Semaphore(1)
 
@@ -206,7 +207,7 @@ class JsonRpcHandler(object):
             while self.running:
                 length = await self.decode_header()
                 if length == -1:
-                    self.running = False
+                    self.shutdown_requested = True
 
                 body = await self.instream.read_bytes(length)
                 body = body.decode("utf8")

--- a/server/src/inmantals/jsonrpc.py
+++ b/server/src/inmantals/jsonrpc.py
@@ -208,6 +208,8 @@ class JsonRpcHandler(object):
                 length = await self.decode_header()
                 if length == -1:
                     self.shutdown_requested = True
+                    self.running = False
+                    return
 
                 body = await self.instream.read_bytes(length)
                 body = body.decode("utf8")

--- a/server/src/inmantals/server.py
+++ b/server/src/inmantals/server.py
@@ -167,6 +167,8 @@ class InmantaLSHandler(JsonRpcHandler):
             }
 
         try:
+            if self.shutdown_requested:
+                return
             # run synchronous part in executor to allow context switching while awaiting
             await asyncio.get_event_loop().run_in_executor(self.threadpool, sync_compile_and_anchor)
             await self.publish_diagnostics(None)
@@ -199,7 +201,8 @@ class InmantaLSHandler(JsonRpcHandler):
         await self.compile_and_anchor()
 
     async def shutdown(self, **kwargs):
-        pass
+        self.shutdown_requested = True
+        self.threadpool.shutdown(wait=True)
 
     async def exit(self, **kwargs):
         self.running = False

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -298,7 +298,7 @@ export async function activate(context: ExtensionContext) {
 }
 
 async function stopServerAndClient() {
-	mutex.runExclusive(async () => {
+	await mutex.runExclusive(async () => {
 		if (client) {
 			await client.stop();
 			client = undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -300,11 +300,15 @@ export async function activate(context: ExtensionContext) {
 async function stopServerAndClient() {
 	await mutex.runExclusive(async () => {
 		if (client) {
-			await client.stop();
+			if(client.needsStop()){
+				await client.stop();
+			}
 			client = undefined;
 		}
 		if(serverProcess){
-			serverProcess.kill();
+			if(!serverProcess.exitCode){
+				serverProcess.kill();
+			}
 			serverProcess = undefined;
 		}
 	});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,11 +32,14 @@ export async function activate(context: ExtensionContext) {
 	}
 	log("Activate Python extension");
 	await pythonExtension.activate();
-	const pythonExtentionApi = new PythonExtension(pythonExtension.exports, restartLS);
+	const pythonExtentionApi = new PythonExtension(pythonExtension.exports, startOrRestartLS);
 
 	let lsOutputChannel = null;
 
 	async function startServerAndClient() {
+		/**
+		 * Should always run under `mutex` lock.
+		 */
 		log("Start server and client");
 		let clientOptions;
 		try {
@@ -45,18 +48,16 @@ export async function activate(context: ExtensionContext) {
 		} catch (err) {
 			return;
 		}
-		await mutex.runExclusive(async () => {
-			try{
-				if (os.platform() === "win32") {
-					await startTcp(clientOptions);
-				} else {
-					await startPipe(clientOptions);
-				}
-			} catch (err) {
-				log(`Could not start Language Server: ${err.message}`);
-				window.showErrorMessage('Inmanta Language Server: rejected to start' + err.message);
+		try{
+			if (os.platform() === "win32") {
+				await startTcp(clientOptions);
+			} else {
+				await startPipe(clientOptions);
 			}
-		});
+		} catch (err) {
+			log(`Could not start Language Server: ${err.message}`);
+			window.showErrorMessage('Inmanta Language Server: rejected to start' + err.message);
+		}
 	}
 
 	async function getClientOptions(): Promise<LanguageClientOptions> {
@@ -153,7 +154,7 @@ export async function activate(context: ExtensionContext) {
 			window.showErrorMessage(`Inmanta Language Server install failed with code ${child.status}, ${child.stderr}`);
 		} else if (startServer) {
 			log(`Starting server and client`);
-			startServerAndClient();
+			startOrRestartLS(true);
 		}
 	}
 
@@ -269,27 +270,29 @@ export async function activate(context: ExtensionContext) {
 		context.subscriptions.push(commands.registerCommand(commandId, commandHandler));
     }
 
-	const enable: boolean = workspace.getConfiguration('inmanta').ls.enabled;
-
-	if (enable) {
-		await startServerAndClient();
+	async function startOrRestartLS(start: boolean = false) {
+		await mutex.runExclusive(async () => {
+			if(start){
+				log("starting Language Server");
+			} else {
+				log("restarting Language Server");
+			}
+			const enable: boolean = workspace.getConfiguration('inmanta').ls.enabled;
+			await stopServerAndClient();
+			if (enable) {
+				startServerAndClient();
+			}
+		});
 	}
 
-	async function restartLS() {
-		log("restarting Language Server");
-		await stopServerAndClient();
-		startServerAndClient();
+	const enable: boolean = workspace.getConfiguration('inmanta').ls.enabled;
+	if (enable) {
+		await startOrRestartLS(true);
 	}
 
 	context.subscriptions.push(workspace.onDidChangeConfiguration(async e => {
 		if (e.affectsConfiguration('inmanta')) {
-			const enable: boolean = workspace.getConfiguration('inmanta').ls.enabled;
-
-			await stopServerAndClient();
-
-			if (enable) {
-				await startServerAndClient();
-			}
+			await startOrRestartLS();
 		}
 	}));
 
@@ -298,22 +301,25 @@ export async function activate(context: ExtensionContext) {
 }
 
 async function stopServerAndClient() {
-	await mutex.runExclusive(async () => {
-		if (client) {
-			if(client.needsStop()){
-				await client.stop();
-			}
-			client = undefined;
+	/**
+	 * Should always execute under the `mutex` lock.
+	 */
+	if (client) {
+		if(client.needsStop()){
+			await client.stop();
 		}
-		if(serverProcess){
-			if(!serverProcess.exitCode){
-				serverProcess.kill();
-			}
-			serverProcess = undefined;
+		client = undefined;
+	}
+	if(serverProcess){
+		if(!serverProcess.exitCode){
+			serverProcess.kill();
 		}
-	});
+		serverProcess = undefined;
+	}
 }
 
 export async function deactivate(){
-	return stopServerAndClient();
+	await mutex.runExclusive(async () => {
+		return stopServerAndClient();
+	});
 }

--- a/src/python_extension.ts
+++ b/src/python_extension.ts
@@ -24,9 +24,9 @@ export class PythonExtension {
 				if(this.executionDetails.execCommand[0] !== newExecutionDetails.execCommand[0]){
 					log(`Active interpreter changed for: ${resource}`);
 					log(`Execution details: ${JSON.stringify(this.executionDetails)}`);
+					this.executionDetails = newExecutionDetails;
 					this.onChangeCallback();
 				}
-				this.executionDetails = newExecutionDetails;
 			}
 		);
 	}

--- a/src/python_extension.ts
+++ b/src/python_extension.ts
@@ -20,14 +20,16 @@ export class PythonExtension {
 	private onChange(pythonApi : IExtensionApi) {
 		pythonApi.settings.onDidChangeExecutionDetails(
 			(resource: Resource) => {
-				log(`Active interpreter changed for: ${resource}`);
-				log(`Execution details: ${JSON.stringify(this.executionDetails)}`);
-				this.executionDetails = pythonApi.settings.getExecutionDetails(resource);
-				this.onChangeCallback();
+				let newExecutionDetails = pythonApi.settings.getExecutionDetails(resource);
+				if(this.executionDetails.execCommand[0] !== newExecutionDetails.execCommand[0]){
+					log(`Active interpreter changed for: ${resource}`);
+					log(`Execution details: ${JSON.stringify(this.executionDetails)}`);
+					this.onChangeCallback();
+				}
+				this.executionDetails = newExecutionDetails;
 			}
 		);
 	}
 
 
   }
-


### PR DESCRIPTION
The log of the tests run showed that every time a language server was started, it was immediately restart. While the configured venv didn't change. Combined with the bug where two language servers would run in parallel for a short period of time, this caused the tests to fail. 