### PR TITLE
fixed LSP for non-vscode client

### DIFF
--- a/server/src/inmantals/server.py
+++ b/server/src/inmantals/server.py
@@ -281,8 +281,9 @@ class InmantaLSHandler(JsonRpcHandler):
 
     async def initialize(
         self,
-        workspaceFolders: Sequence[Dict],
         capabilities: Dict[str, object],
+        *,
+        workspaceFolders: Optional[Sequence[Dict]] = None,
         rootPath=None,
         rootUri=None,
         **kwargs,


### PR DESCRIPTION
We checked if it was `None` but it was not optional so the server initialization returned with an error.

closes #1068