### PR TITLE
Revert typing bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,5 @@ updates:
   ignore:
     - dependency-name: "get-port"
       update-types: ["version-update:semver-major"]
+    - dependency-name: "@types/vscode"
+      update-types: ["version-update:semver-minor"]

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.15.11",
         "@types/semver": "^7.3.13",
-        "@types/vscode": "^1.77.0",
+        "@types/vscode": "^1.63.2",
         "@typescript-eslint/eslint-plugin": "^5.59.0",
         "@typescript-eslint/parser": "^5.59.0",
         "@vscode/test-electron": "^2.2.3",


### PR DESCRIPTION
The version of @types/vscode should stay aligned with the vscode version. 
As we did not make any breaking changes we don't want to bump the minimal vscode version and so the @types/vscode can not be bumped