### PR TITLE
remove pattern for document selector in LanguageClientOptions

### DIFF
--- a/server/src/inmantals/server.py
+++ b/server/src/inmantals/server.py
@@ -554,6 +554,7 @@ class InmantaLSHandler(JsonRpcHandler):
         uri = prefix + location.file
         if self.tmp_project:
             uri = self.replace_tmp_path(uri)
+
         if isinstance(location, Range):
             return {
                 "uri": uri,

--- a/server/src/inmantals/server.py
+++ b/server/src/inmantals/server.py
@@ -554,7 +554,6 @@ class InmantaLSHandler(JsonRpcHandler):
         uri = prefix + location.file
         if self.tmp_project:
             uri = self.replace_tmp_path(uri)
-
         if isinstance(location, Range):
             return {
                 "uri": uri,
@@ -627,7 +626,7 @@ class InmantaLSHandler(JsonRpcHandler):
 
         data = list(range)[0].data
         docstring = textwrap.dedent(data.docstring.strip("\n")) if data.docstring else ""
-        docstring = docstring.replace(" ", "&nbsp;")
+        docstring = docstring.replace(" ", "&nbsp;").replace("\n", "\n\n").strip()
         definition = self.get_definition(data).strip()
         language = self.get_file_type(data.location.file)
         definition_md = f"""

--- a/src/language_server.ts
+++ b/src/language_server.ts
@@ -7,11 +7,11 @@ import * as path from "path";
 import * as fs from "fs";
 import getPort from 'get-port';
 
-import { commands, ExtensionContext, OutputChannel, window, workspace, Uri, WorkspaceFolder} from 'vscode';
+import { commands, ExtensionContext, OutputChannel, window, workspace, Uri, WorkspaceFolder, LocationLink, Location, Definition} from 'vscode';
 import { RevealOutputChannelOn, LanguageClientOptions, integer, ErrorHandler, Message, ErrorHandlerResult, ErrorAction, CloseHandlerResult, CloseAction} from 'vscode-languageclient';
 import { LanguageClient, ServerOptions } from 'vscode-languageclient/node';
 import { Mutex } from 'async-mutex';
-import { fileOrDirectoryExists, log } from './utils';
+import { fileOrDirectoryExists, isLocation, log } from './utils';
 import { v4 as uuidv4 } from 'uuid';
 import { getLanguageMap } from './extension';
 
@@ -372,6 +372,37 @@ export class LanguageServer {
 	}
 
 	/**
+	 * Provide the definition of a symbol at a given position in the document.
+	 * @param {TextDocument} document The text document to get the definition from.
+	 * @param {Position} position The position within the document to get the definition for.
+	 * @param {CancellationToken} token A cancellation token.
+	 * @param {ProvideDefinitionSignature} next The next provider to call.
+	 * @returns {Promise<Definition | LocationLink[] | undefined>} A Promise that resolves to a
+	 * Definition, an array of LocationLinks, or undefined. If an array of LocationLinks is
+	 * returned, the locations are filtered to remove any that do not have a valid uri path.
+	 * If the definition has an undefined uri path, returns undefined.
+	 */
+	private	async middlewareProvideDefinition(document, position, token, next){
+		const definition: LocationLink[] | Definition = await next(document, position, token);
+		if (Array.isArray(definition)) {
+		  // Filter the definition array to keep only Location objects with defined URIs
+		  const filteredDefinition = (definition as Location[])
+			  .filter(
+				  (loc): loc is Location =>
+				  (isLocation(loc) && loc.uri.path !== "/undefined")
+			  );
+		  return filteredDefinition;
+		} else {
+		  // If the definition is not an array, check if the URI path is undefine
+		  if (definition.uri.path === "/undefined") {
+			  return undefined;
+		  }
+		  return definition;
+		}
+	  }
+
+
+	/**
 	 * Get options for initializing the language client.
 	 * @returns {Promise<LanguageClientOptions>} A Promise that resolves to an object containing options for the language client,
 	 * 		including document selector, error handler, output channel settings, and initialization options.
@@ -405,7 +436,10 @@ export class LanguageServer {
 
 		const clientOptions: LanguageClientOptions = {
 			// Register the server for inmanta documents living under the root folder.
-			documentSelector: [{ scheme: 'file', language: 'inmanta', pattern: `${this.rootFolder.uri.fsPath}/**/*`}],
+			documentSelector: [{ scheme: 'file', language: 'inmanta'}],
+			middleware: {
+				provideDefinition: this.middlewareProvideDefinition
+			},
 			outputChannel: this.lsOutputChannel,
 			revealOutputChannelOn: RevealOutputChannelOn.Info,
 			errorHandler: this.errorHandler,

--- a/src/language_server.ts
+++ b/src/language_server.ts
@@ -377,10 +377,10 @@ export class LanguageServer {
 	 * @param {Position} position The position within the document to get the definition for.
 	 * @param {CancellationToken} token A cancellation token.
 	 * @param {ProvideDefinitionSignature} next The next provider to call.
-	 * @returns {Promise<Definition | LocationLink[] | undefined>} A Promise that resolves to a
-	 * Definition, an array of LocationLinks, or undefined. If an array of LocationLinks is
-	 * returned, the locations are filtered to remove any that do not have a valid uri path.
-	 * If the definition has an undefined uri path, returns undefined.
+	 * @returns {Promise<Location | Location[] | undefined>} A Promise that resolves to a
+	 * Location, an array of Location, or undefined. If an array of Location is
+	 * returned by 'next', the locations are filtered to remove any that do not have a valid uri path.
+	 * If the Location returned by 'next' has an undefined uri path, returns undefined.
 	 */
 	private async middlewareProvideDefinition(
 		document: TextDocument,
@@ -388,9 +388,9 @@ export class LanguageServer {
 		token: CancellationToken,
 		next: ProvideDefinitionSignature
 	  ): Promise<Location | Location[] | undefined> {
-		const definition: Definition | LocationLink[] = await next(document, position, token);
+		const definition: Location | Location[] = await next(document, position, token) as Definition;
 		if (Array.isArray(definition)) {
-			const filteredDefinition = (definition as Location[]).filter(
+			const filteredDefinition:Location[] = definition.filter(
 				(loc): loc is Location => (isLocation(loc) && loc.uri.path !== "/undefined")
 			);
 			return filteredDefinition;

--- a/src/test/docstrings/docstrings.test.ts
+++ b/src/test/docstrings/docstrings.test.ts
@@ -63,12 +63,6 @@ This&nbsp;is:
 
 
 &nbsp;&nbsp;&nbsp;&nbsp;my&nbsp;docstring&nbsp;with&nbsp;some&nbsp;keywords&nbsp;like&nbsp;if&nbsp;for&nbsp;entity&nbsp;end&nbsp;0&nbsp;1&nbsp;2`;
-			console.log("-------------------------------");
-			console.log(expectedWeirdDocstringEntity);
-			console.log("-------------------------------");
-			console.log(weirdDocstringEntity[0].contents[0].value);
-			console.log("-------------------------------");
-
 			assert.strictEqual(weirdDocstringEntity[0].contents[0].value, expectedWeirdDocstringEntity, "wrong docstring Plugin");
 
 			resolve();

--- a/src/test/docstrings/docstrings.test.ts
+++ b/src/test/docstrings/docstrings.test.ts
@@ -25,14 +25,14 @@ describe('Language Server Code docstrings', () => {
 			const succeeded = await waitForCompile(logPath, 25000);
 			assert.strictEqual(succeeded, true, "Compilation didn't succeed");
 			const docstringEntity = await commands.executeCommand("vscode.executeHoverProvider", modelUri, new Position(13, 11));
-			const expectedDocstringEntity = `
+
+			let expectedDocstringEntity: string = `
 \`\`\`inmanta
 entity Person:
 \`\`\`
 
 ___
-the&nbsp;entity&nbsp;for&nbsp;a&nbsp;Person
-`;
+the&nbsp;entity&nbsp;for&nbsp;a&nbsp;Person`;
 			assert.strictEqual(docstringEntity[0].contents[0].value, expectedDocstringEntity, "wrong docstring Entity");
 
 			const docstringPlugin = await commands.executeCommand("vscode.executeHoverProvider", modelUri, new Position(21, 14));
@@ -42,11 +42,35 @@ def noop(message: "any"):
 \`\`\`
 
 ___
-returns&nbsp;the&nbsp;input
+blablabla&nbsp;nononop
 
-:param&nbsp;message:&nbsp;a&nbsp;message&nbsp;as&nbsp;input
-`;
-			assert.strictEqual(docstringPlugin[0].contents[0].value, expectedDocstringPlugin, "wrong docstring Entity");
+:param&nbsp;message:a&nbsp;message
+
+:return:&nbsp;nothing`;
+
+			assert.strictEqual(docstringPlugin[0].contents[0].value, expectedDocstringPlugin, "wrong docstring Plugin");
+
+
+			const weirdDocstringEntity = await commands.executeCommand("vscode.executeHoverProvider", modelUri, new Position(43, 14));
+			const expectedWeirdDocstringEntity = `
+\`\`\`inmanta
+entity EntityWeirdDoc:
+\`\`\`
+
+___
+This&nbsp;is:
+
+
+
+&nbsp;&nbsp;&nbsp;&nbsp;my&nbsp;docstring&nbsp;with&nbsp;some&nbsp;keywords&nbsp;like&nbsp;if&nbsp;for&nbsp;entity&nbsp;end&nbsp;0&nbsp;1&nbsp;2`;
+			console.log("-------------------------------");
+			console.log(expectedWeirdDocstringEntity);
+			console.log("-------------------------------");
+			console.log(weirdDocstringEntity[0].contents[0].value);
+			console.log("-------------------------------");
+
+			assert.strictEqual(weirdDocstringEntity[0].contents[0].value, expectedWeirdDocstringEntity, "wrong docstring Plugin");
+
 			resolve();
 		});
 	}).timeout(0);

--- a/src/test/docstrings/workspace/libs/testmodule/plugins/__init__.py
+++ b/src/test/docstrings/workspace/libs/testmodule/plugins/__init__.py
@@ -4,8 +4,8 @@ from inmanta.plugins import plugin
 @plugin()
 def noop(message: "any"):
     """
-    returns the input
-
-    :param message: a message as input
+    blablabla nononop
+    :param message:a message
+    :return: nothing
     """
     return message

--- a/src/test/docstrings/workspace/main.cf
+++ b/src/test/docstrings/workspace/main.cf
@@ -42,3 +42,4 @@ end
 implement EntityWeirdDoc using std::none
 
 hoho = EntityWeirdDoc()
+

--- a/src/test/navigation/workspace/libs/testmodule/plugins/__init__.py
+++ b/src/test/navigation/workspace/libs/testmodule/plugins/__init__.py
@@ -3,4 +3,10 @@ from inmanta.plugins import plugin
 
 @plugin()
 def noop(message: "any"):
+    """
+    blablabla nononop
+
+    :param message:a message
+    :return: nothing
+    """
     return message

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -45,30 +45,30 @@ async function main() {
 		stdio: 'inherit'
 		});
 
-		// await runTests({
-		// 	vscodeExecutablePath,
-		// 	extensionDevelopmentPath: extensionDevelopmentPath,
-		// 	extensionTestsPath: path.resolve(__dirname, './loadExtension/index'),
-		// 	launchArgs: ["--disable-gpu"],
-		// 	extensionTestsEnv,
-		// 	reuseMachineInstall: true,
-		// });
+		await runTests({
+			vscodeExecutablePath,
+			extensionDevelopmentPath: extensionDevelopmentPath,
+			extensionTestsPath: path.resolve(__dirname, './loadExtension/index'),
+			launchArgs: ["--disable-gpu"],
+			extensionTestsEnv,
+			reuseMachineInstall: true,
+		});
 
-		// await runTests({
-		// 	vscodeExecutablePath,
-		// 	launchArgs: [path.resolve(__dirname, '../../src/test/compile/workspace'), "--disable-gpu"],
-		// 	extensionDevelopmentPath,
-		// 	extensionTestsPath: path.resolve(__dirname, './compile/index'),
-		// 	reuseMachineInstall: true,
-		// });
+		await runTests({
+			vscodeExecutablePath,
+			launchArgs: [path.resolve(__dirname, '../../src/test/compile/workspace'), "--disable-gpu"],
+			extensionDevelopmentPath,
+			extensionTestsPath: path.resolve(__dirname, './compile/index'),
+			reuseMachineInstall: true,
+		});
 
-		// await runTests({
-		// 	vscodeExecutablePath,
-		// 	extensionDevelopmentPath: extensionDevelopmentPath,
-		// 	extensionTestsPath: path.resolve(__dirname, './navigation/index'),
-		// 	launchArgs: [path.resolve(__dirname, '../../src/test/navigation/workspace'), "--disable-gpu"],
-		// 	reuseMachineInstall: true,
-		// });
+		await runTests({
+			vscodeExecutablePath,
+			extensionDevelopmentPath: extensionDevelopmentPath,
+			extensionTestsPath: path.resolve(__dirname, './navigation/index'),
+			launchArgs: [path.resolve(__dirname, '../../src/test/navigation/workspace'), "--disable-gpu"],
+			reuseMachineInstall: true,
+		});
 
 		await runTests({
 			vscodeExecutablePath,

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -45,30 +45,30 @@ async function main() {
 		stdio: 'inherit'
 		});
 
-		await runTests({
-			vscodeExecutablePath,
-			extensionDevelopmentPath: extensionDevelopmentPath,
-			extensionTestsPath: path.resolve(__dirname, './loadExtension/index'),
-			launchArgs: ["--disable-gpu"],
-			extensionTestsEnv,
-			reuseMachineInstall: true,
-		});
+		// await runTests({
+		// 	vscodeExecutablePath,
+		// 	extensionDevelopmentPath: extensionDevelopmentPath,
+		// 	extensionTestsPath: path.resolve(__dirname, './loadExtension/index'),
+		// 	launchArgs: ["--disable-gpu"],
+		// 	extensionTestsEnv,
+		// 	reuseMachineInstall: true,
+		// });
 
-		await runTests({
-			vscodeExecutablePath,
-			launchArgs: [path.resolve(__dirname, '../../src/test/compile/workspace'), "--disable-gpu"],
-			extensionDevelopmentPath,
-			extensionTestsPath: path.resolve(__dirname, './compile/index'),
-			reuseMachineInstall: true,
-		});
+		// await runTests({
+		// 	vscodeExecutablePath,
+		// 	launchArgs: [path.resolve(__dirname, '../../src/test/compile/workspace'), "--disable-gpu"],
+		// 	extensionDevelopmentPath,
+		// 	extensionTestsPath: path.resolve(__dirname, './compile/index'),
+		// 	reuseMachineInstall: true,
+		// });
 
-		await runTests({
-			vscodeExecutablePath,
-			extensionDevelopmentPath: extensionDevelopmentPath,
-			extensionTestsPath: path.resolve(__dirname, './navigation/index'),
-			launchArgs: [path.resolve(__dirname, '../../src/test/navigation/workspace'), "--disable-gpu"],
-			reuseMachineInstall: true,
-		});
+		// await runTests({
+		// 	vscodeExecutablePath,
+		// 	extensionDevelopmentPath: extensionDevelopmentPath,
+		// 	extensionTestsPath: path.resolve(__dirname, './navigation/index'),
+		// 	launchArgs: [path.resolve(__dirname, '../../src/test/navigation/workspace'), "--disable-gpu"],
+		// 	reuseMachineInstall: true,
+		// });
 
 		await runTests({
 			vscodeExecutablePath,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { workspace, WorkspaceFolder, Uri } from 'vscode';
+import { workspace, WorkspaceFolder, Uri, Location } from 'vscode';
 import { LanguageServer } from './language_server';
 import {getSortedWorkspaceFolders} from './extension';
 
@@ -59,7 +59,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 */
 
 function sortedWorkspaceFolders(): string[] {
-	let _sortedWorkspaceFolders = getSortedWorkspaceFolders(); 
+	let _sortedWorkspaceFolders = getSortedWorkspaceFolders();
 	if (_sortedWorkspaceFolders === void 0) {
 		_sortedWorkspaceFolders = workspace.workspaceFolders ? workspace.workspaceFolders.map(folder => {
 			let result = folder.uri.toString();
@@ -89,4 +89,9 @@ export function getOuterMostWorkspaceFolder(folder: WorkspaceFolder): WorkspaceF
 		}
 	}
 	return folder;
+}
+
+
+export function isLocation(loc: any): loc is Location {
+	return loc.uri !== undefined;
 }


### PR DESCRIPTION
This pr removes the filter pattern for document selector in LanguageClientOptions. It will then filter out all undefined results out of the responses provided the the different LS's. 

`middleware` and more particulary `middlewareProvideDefinition` were added to remove the unwanted responses returned by all the started LS:
As all the language servers now react to the `textDocument_definition` call, a lot of them don't have the asked definition in their `anchormap`. This causes them to return "/undefined". Without the middleware, when trying to navigate with ctrl+click, vscode would propose (with a popup) all the location returned by the different LSes. which resulted in the right location and a "/undefined" option. The `middlewareProvideDefinition` will remove all the "/undefined" propositions. 

closes #1136 