### PR TITLE
issue/1250-syntax-highlight

### DIFF
--- a/syntaxes/inmanta.json
+++ b/syntaxes/inmanta.json
@@ -212,7 +212,7 @@
           "match": "\\b(using|extends|matching|for|with|when|as|if|else|elif)\\b"
         },
         {
-          "name": "keyword.operator.inmanta",
+          "name": "keyword.operator.new.inmanta",
           "match": "\\b(in|or|and|is defined)\\b"
         }
       ]


### PR DESCRIPTION
`is defined` and `in` will now be highlighted