### PR TITLE
drop iso4/iso5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 1.5.0 (?)
 Changes in this release:
+- Drop support for iso4/iso5
 
 # v 1.4.0 (2023-06-06)
 Changes in this release:

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -6,9 +6,6 @@ requires =
     virtualenv<20.22.0
     wheel
 
-[testenv:py39]
-basepython=python3.9
-
 [testenv]
 deps=
     -rrequirements.dev.txt

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py39-inm{master,iso6-stable,latest}
+envlist = pep8,py39-inmiso6-stable,py311-{master,latest}
 skip_missing_interpreters=True
 requires =
     pip >= 21.0.1

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -1,13 +1,10 @@
 [tox]
-envlist = pep8,py36-inmiso4-stable,py39-inm{master,iso6-stable,iso5-stable,latest}
+envlist = pep8,py39-inm{master,iso6-stable,latest}
 skip_missing_interpreters=True
 requires =
     pip >= 21.0.1
     virtualenv<20.22.0
     wheel
-
-[testenv:py36]
-basepython=python3.6
 
 [testenv:py39]
 basepython=python3.9
@@ -18,8 +15,6 @@ deps=
     -rrequirements.txt
     inmlatest: inmanta-core
     inmmaster: git+https://github.com/inmanta/inmanta-core.git
-    inmiso4-stable: git+https://github.com/inmanta/inmanta-core.git@iso4-stable
-    inmiso5-stable: git+https://github.com/inmanta/inmanta-core.git@iso5-stable
     inmiso6-stable: git+https://github.com/inmanta/inmanta-core.git@iso6-stable
 
 commands=py.test --junitxml=junit-{envname}.xml -vvv tests/


### PR DESCRIPTION
The vscode tests where still running agains iso4-stable and iso5-stable but those branches don't exist anymore