### PR TITLE
Add workaround for bug in pythonExtension.getExecutionDetails() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 1.5.0 (?)
 Changes in this release:
 - Drop support for iso4/iso5
+- Add workaround for bug in the python extension where `getExecutionDetails().execCommand[0]` returns the path to the root of the venv instead of the path to the python binary in that venv.
 
 # v 1.4.0 (2023-06-06)
 Changes in this release:

--- a/src/python_extension.ts
+++ b/src/python_extension.ts
@@ -4,6 +4,7 @@ import { StatusBarAlignment, ThemeColor, window, workspace, TextDocument, Worksp
 import { IExtensionApi, Resource } from './types';
 import { fileOrDirectoryExists, log, getOuterMostWorkspaceFolder, logMap} from './utils';
 import { getLanguageMap, getLastActiveFolder} from './extension';
+import * as fs from "fs";
 
 
 export const PYTHONEXTENSIONID = "ms-python.python";
@@ -31,11 +32,43 @@ export class PythonExtension {
 	 * @returns {string} A string representing the path to the Python interpreter.
 	 */
 	get pythonPath(): string {
-		return this.executionDetails.execCommand[0];
+		return PythonExtension.getPathPythonBinary(this.executionDetails.execCommand[0]);
 	}
 
 	get virtualEnvName(): string | null {
 		return this.pythonPathToEnvName(this.pythonPath);
+	}
+
+
+	/**
+	 * Due to bug https://github.com/microsoft/vscode-python/issues/22617, the `this.pythonApi.settings.getExecutionDetails()` method
+	 * might return the path to the root of the venv instead of the path to the python binary in that venv. This method exists to work
+	 * around that issue.
+	 */
+	private static getPathPythonBinary(execCommand: string): string {
+		if(PythonExtension.isFile(execCommand)){
+			return execCommand;
+		}
+		for(const pythonSuffix of ["python3", "python"]){
+			const execCommandWithSuffix = execCommand + "/bin/" + pythonSuffix;
+			if(PythonExtension.isFile(execCommandWithSuffix)){
+				return execCommandWithSuffix
+			}
+		}
+		throw new Error(`Failed to find python binary ${execCommand}`);
+	}
+
+
+	/**
+	 * @returns {boolean} True iff the given path references a file (or symbolic link to file).
+	 */
+	private static isFile(path: string): boolean {
+		try{
+			const stat = fs.statSync(path);
+			return stat.isFile();
+		} catch(err){
+			return false;
+		}
 	}
 
 	pythonPathToEnvName(path: string) : string {
@@ -141,7 +174,8 @@ export class PythonExtension {
 
 	getPathForResource(resource) {
 		try{
-			return this.pythonApi.settings.getExecutionDetails(resource).execCommand[0];
+			const execDetails = this.pythonApi.settings.getExecutionDetails(resource);
+			return PythonExtension.getPathPythonBinary(execDetails.execCommand[0]);
 		} catch (error){
 			console.error(`Failed to getPathForResource   :` + error.name + error.message);
 		}
@@ -160,8 +194,9 @@ export class PythonExtension {
 
 				if(this.executionDetails.execCommand[0] !== newExecutionDetails.execCommand[0]){
 					this.executionDetails = newExecutionDetails;
+					const newPathPythonBinary = PythonExtension.getPathPythonBinary(newExecutionDetails.execCommand[0]);
 					for (const callback of this.callBacksOnchange) {
-						callback(newExecutionDetails.execCommand[0], outermost);
+						callback(newPathPythonBinary, outermost);
 					}
 				}
 			}

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -40,7 +40,7 @@ async function main() {
 
 		const vscodeExecutablePath = await downloadAndUnzipVSCode('stable');
 		const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath, "linux-x64");
-		cp.spawnSync(cliPath, ['--install-extension', 'ms-python.python'], {
+		cp.spawnSync(cliPath, ['--install-extension', 'ms-python.python', '--force'], {
 		encoding: 'utf-8',
 		stdio: 'inherit'
 		});


### PR DESCRIPTION
[This bug](https://github.com/microsoft/vscode-python/issues/22617) in the Python extension causes the `this.pythonApi.settings.getExecutionDetails().execCommand[0]` to return the path to the root of the venv instead of the path to the python binary in that venv. This PR applies a workaround for this issue until it's fix in the python extension.

Closes #1508 