### PR TITLE
Fix bug in the release pipeline of the vscode extension

### DIFF
--- a/.ci/Jenkinsfile-extension-vsce
+++ b/.ci/Jenkinsfile-extension-vsce
@@ -100,8 +100,8 @@ pipeline {
                             git merge -X theirs issue/version-bump-extension
 
 
-                            if [ -f "requirements.txt" ]; then
-                                echo "Error: requirements.txt already exists. Stopping execution."
+                            if [ -f "requirements.txt" ] && [ -n "$(grep -v 'inmantals~=' requirements.txt)" ]; then
+                                echo "Error: requirements.txt already exists and it contains more than just the inmantals dependency. Stopping execution."
                                 exit 1
                             fi
 
@@ -120,9 +120,13 @@ pipeline {
                             fi
 
                             echo "inmantals~=${ls_version}" > requirements.txt
-                            # force add requirements.txt as it is part of .gitignore
-                            git add requirements.txt -f
-                            git commit -m "add requirements.txt file to tie the inmantals version (${ls_version}) to the extension"
+                            git diff --exit-code requirements.txt
+                            requirements_txt_has_changed=$?
+                            if [ ${requirements_txt_has_changed} -ne 0 ]; then
+                                # force add requirements.txt as it is part of .gitignore
+                                git add requirements.txt -f
+                                git commit -m "add requirements.txt file to tie the inmantals version (${ls_version}) to the extension"
+                            fi
 
                             git push origin next
 
@@ -257,3 +261,4 @@ pipeline {
         }
     }
 }
+


### PR DESCRIPTION
The pipeline was failing because the `requirements.txt` file was already present on the next branch.