### PR TITLE
Fix language servers stop/start logic + fix memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 1.7.0 (?)
 Changes in this release:
+- Fix bug that could cause multiple instances of the language server to be running simultaneously.
 
 # v 1.6.0 (2024-01-24)
 Changes in this release:

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 1.6.0 (?)
 Changes in this release:
+- Fix memory leak by resetting the `inmanta.plugins.PluginMeta` and `inmanta.export.Exporter` classes after every compile.
 
 # v 1.5.0 (2023-12-21)
 Changes in this release:

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v 1.6.0 (?)
 Changes in this release:
-- Fix memory leak by resetting the `inmanta.plugins.PluginMeta` and `inmanta.export.Exporter` classes after every compile.
+- Fix memory leak by resetting the `inmanta.plugins.PluginMeta` and `inmanta.export.Exporter` classes before every compile.
 
 # v 1.5.0 (2023-12-21)
 Changes in this release:

--- a/server/src/inmantals/server.py
+++ b/server/src/inmantals/server.py
@@ -42,9 +42,9 @@ from inmanta.ast import CompilerException, Location, Range
 from inmanta.ast.entity import Entity, Implementation
 from inmanta.config import is_bool
 from inmanta.execute import scheduler
+from inmanta.export import Exporter
 from inmanta.module import Project
 from inmanta.plugins import Plugin, PluginMeta
-from inmanta.export import Exporter
 from inmanta.util import groupby
 from inmantals import lsp_types
 from inmantals.jsonrpc import InvalidParamsException, JsonRpcHandler, MethodNotFoundException

--- a/server/src/inmantals/server.py
+++ b/server/src/inmantals/server.py
@@ -43,7 +43,8 @@ from inmanta.ast.entity import Entity, Implementation
 from inmanta.config import is_bool
 from inmanta.execute import scheduler
 from inmanta.module import Project
-from inmanta.plugins import Plugin
+from inmanta.plugins import Plugin, PluginMeta
+from inmanta.export import Exporter
 from inmanta.util import groupby
 from inmantals import lsp_types
 from inmantals.jsonrpc import InvalidParamsException, JsonRpcHandler, MethodNotFoundException
@@ -480,6 +481,9 @@ class InmantaLSHandler(JsonRpcHandler):
             # reset all
             resources.resource.reset()
             handler.Commander.reset()
+            PluginMeta.clear()
+            if hasattr(Exporter, "clear"):  # Remain backwards-compatible with older version of inmanta-core
+                Exporter.clear()
 
             setup_project(self.root_folder)
 
@@ -568,7 +572,6 @@ class InmantaLSHandler(JsonRpcHandler):
         except InvalidExtensionSetup as e:
             await self.handle_invalid_extension_setup(e)
             logger.error(e)
-
         except Exception as e:
             logger.debug(e)
 

--- a/src/language_server.ts
+++ b/src/language_server.ts
@@ -499,10 +499,14 @@ export class LanguageServer {
 
 	/**
 	 * Starts the TCP server and the Inmanta Language Server.
+	 * This function should always run under the `mutex` lock.
 	 *
 	 * @param clientOptions The options for the language client.
 	 */
 	private async startTcp(clientOptions: LanguageClientOptions) {
+		if(this.client){
+			return;
+		}
 		const host = "127.0.0.1";
 		// Get a random free port on 127.0.0.1
 		const serverPort = await getPort({ host: host });
@@ -568,10 +572,14 @@ export class LanguageServer {
 
 	/**
 	 * Starts the Inmanta Language Server by creating a new LanguageClient and starting it with the given clientOptions.
+	 * This function should always run under the `mutex` lock.
 	 *
 	 * @param {LanguageClientOptions} clientOptions The options for the LanguageClient.
 	 */
 	async startPipe(clientOptions: LanguageClientOptions) {
+		if(this.client){
+			return;
+		}
 		log(`Python path is ${this.pythonPath}`);
 
 		const serverOptions: ServerOptions = {
@@ -619,33 +627,46 @@ export class LanguageServer {
 			log("restarting Language Server");
 		}
 		const enable: boolean = workspace.getConfiguration('inmanta').ls.enabled;
-		await this.stopServerAndClient();
-		if (enable) {
-			await this.startServerAndClient();
-			window.showInformationMessage(`The Language server has been enabled for folder ${this.rootFolder.name}`);
-		}
-
+		await this.mutex.runExclusive(async () => {
+			await this.stopServerAndClient(false);
+			if (enable) {
+				await this.startServerAndClient();
+				window.showInformationMessage(`The Language server has been enabled for folder ${this.rootFolder.name}`);
+			}
+		});
 	}
 
 	/**
 	 * Stops the language server and its client.
 	 */
-	async stopServerAndClient() {
+	async stopServerAndClient(acquire_lock: boolean = true) {
 		log("Stopping server and client...");
-		await this.mutex.runExclusive(async () => {
-			if (this.client) {
-				if(this.client.needsStop()){
-					await this.client.stop();
-				}
-				this.client = undefined;
+		if(acquire_lock){
+			await this.mutex.runExclusive(async () => {
+				await this._stopServerAndClient();
+			});
+		} else {
+			await this._stopServerAndClient();
+		}
+	}
+
+	/* 
+	 * Stops the language server and its client.
+	 * This function should always run under the `mutex` lock.
+	 */
+	async _stopServerAndClient() {
+		if (this.client) {
+			if(this.client.needsStop()){
+				await this.client.stop();
 			}
-			if(this.serverProcess){
-				if(!this.serverProcess.exitCode){
-					this.serverProcess.kill();
-				}
-				this.serverProcess = undefined;
+			this.client = undefined;
+		}
+		if(this.serverProcess){
+			if(!this.serverProcess.exitCode){
+				this.serverProcess.kill();
 			}
-		});
+			this.serverProcess = undefined;
+		}
 	}
 
 	cleanOutputChannel() {

--- a/src/language_server.ts
+++ b/src/language_server.ts
@@ -638,6 +638,9 @@ export class LanguageServer {
 
 	/**
 	 * Stops the language server and its client.
+	 *
+	 * @param {acquire_lock} If this parameter is set to false, the `mutex` lock must be acquired by the caller.
+	 *                       Otherwise this method acquires the lock itself.
 	 */
 	async stopServerAndClient(acquire_lock: boolean = true) {
 		log("Stopping server and client...");


### PR DESCRIPTION
changes:

* Fix bug that could cause multiple instances of the language server to be running simultaneously.
* Fix memory leak by resetting the `inmanta.plugins.PluginMeta` and `inmanta.export.Exporter` classes before every compile.