### PR TITLE
Fix linting issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "scripts": {
         "vscode:prepublish": "npm run compile",
         "compile": "rimraf out && tsc -p ./",
-        "lint": "eslint src --ext ts",
+        "lint": "eslint --max-warnings 0 src --ext ts",
         "watch": "rimraf out && tsc -watch -p ./",
         "pretest": "npm run compile && npm run lint",
         "test": "node ./out/test/runTest.js"

--- a/src/language_server.ts
+++ b/src/language_server.ts
@@ -639,12 +639,12 @@ export class LanguageServer {
 	/**
 	 * Stops the language server and its client.
 	 *
-	 * @param {acquire_lock} If this parameter is set to false, the `mutex` lock must be acquired by the caller.
+	 * @param {acquireLock} If this parameter is set to false, the `mutex` lock must be acquired by the caller.
 	 *                       Otherwise this method acquires the lock itself.
 	 */
-	async stopServerAndClient(acquire_lock: boolean = true) {
+	async stopServerAndClient(acquireLock: boolean = true) {
 		log("Stopping server and client...");
-		if(acquire_lock){
+		if(acquireLock){
 			await this.mutex.runExclusive(async () => {
 				await this._stopServerAndClient();
 			});


### PR DESCRIPTION
* Fix linting issue with respect to `acquireLock` variable.
* Make sure that the ci pipeline raises an error for these types of warnings instead of just displaying the warning in the log.