### PR TITLE
Fix bug in release pipeline of extension

### DIFF
--- a/.ci/Jenkinsfile-extension-vsce
+++ b/.ci/Jenkinsfile-extension-vsce
@@ -120,8 +120,10 @@ pipeline {
                             fi
 
                             echo "inmantals~=${ls_version}" > requirements.txt
+                            set +e
                             git diff --exit-code requirements.txt
                             requirements_txt_has_changed=$?
+                            set -e
                             if [ ${requirements_txt_has_changed} -ne 0 ]; then
                                 # force add requirements.txt as it is part of .gitignore
                                 git add requirements.txt -f


### PR DESCRIPTION
The pipeline fails if the `git diff --exit-code requirements.txt` command exists with a non-zero exit code, namely when there is a diff. The `set +e` and `set -e` demarcation makes sure that the pipeline doesn't fail when any of the containing commands exist with a non-zero exit code