### PR TITLE
Use python3.12 when running against master

### DIFF
--- a/server/tox.ini
+++ b/server/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py311-{master,latest,inmiso7-stable}
+envlist = pep8,py311-inmiso7-stable,py312-{master,latest}
 skip_missing_interpreters=True
 requires =
     pip >= 21.0.1
@@ -9,8 +9,8 @@ requires =
 deps=
     -rrequirements.dev.txt
     -rrequirements.txt
-    py311-latest: inmanta-core
-    py311-master: git+https://github.com/inmanta/inmanta-core.git
+    py312-latest: inmanta-core
+    py312-master: git+https://github.com/inmanta/inmanta-core.git
     py311-inmiso7-stable: git+https://github.com/inmanta/inmanta-core.git@iso7-stable
 
 commands=py.test --junitxml=junit-{envname}.xml -vvv -s tests/


### PR DESCRIPTION
Make sure we run the tests for master using python3.12 instead of python3.11