### PR TITLE
Add test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ If you are contributing or developing for the extention, here are the steps requ
         - `sudo apt install python3.12`
 - `python3.12 -m venv /tmp/venv`
 - `export INMANTA_EXTENSION_TEST_ENV=/tmp/venv`
+- `export INMANTA_LS_LOG_PATH=/tmp/venv/server.log`
+- `export DISPLAY=:0` (only for Windows/WSL)
 - `/tmp/venv/bin/python -m pip install ./server`
 
 You can now launch the tests either with the debugger, or with `npm run test`.

--- a/src/language_server.ts
+++ b/src/language_server.ts
@@ -225,19 +225,25 @@ export class LanguageServer {
 			return LanguageServerDiagnoseResult.wrongInterpreter;
 		}
 
-		const script = "import sys\n" +
-			"if sys.version_info[0] != 3 or sys.version_info[1] < 6:\n" +
-			"  sys.exit(4)\n" +
-			"try:\n" +
-			"  import inmantals\n" +
-			"  sys.exit(0)\n" +
-			"except ModuleNotFoundError:\n" +
-			"  real_prefix = getattr(sys, 'real_prefix', None)\n" +
-			"  base_prefix = getattr(sys, 'base_prefix', sys.prefix)\n" +
-			"  running_in_virtualenv = (base_prefix or real_prefix) != sys.prefix\n" +
-			"  if not running_in_virtualenv:\n" +
-			"    sys.exit(5)\n" +
-			"  sys.exit(3)";
+		/**
+		 * Check Python Version: It checks if the Python version is 3.6 or higher. If not, it exits with status code 4
+		 * Try to Import a Module: It tries to import the inmantals module. If the import is successful, it exits with status code 0.
+		 * Try to Import a Module: It tries to import the inmantals module. If the import is successful, it exits with status code 0.
+		 * Check Virtual Environment: If the script is not running in a virtual environment, it exits with status code 5. Otherwise, it exits with status code 3.
+		 */
+		const script = `import sys
+			if sys.version_info[0] != 3 or sys.version_info[1] < 6:
+				sys.exit(4)
+			try:
+				import inmantals
+				sys.exit(0)
+			except ModuleNotFoundError:
+				real_prefix = getattr(sys, 'real_prefix', None)
+				base_prefix = getattr(sys, 'base_prefix', sys.prefix)
+				running_in_virtualenv = (base_prefix or real_prefix) != sys.prefix
+				if not running_in_virtualenv:
+					sys.exit(5)
+				sys.exit(3)`;
 
 		const spawnResult = cp.spawnSync(pythonPath, ["-c", script]);
 		const stdout = spawnResult.stdout.toString();

--- a/src/language_server.ts
+++ b/src/language_server.ts
@@ -235,7 +235,6 @@ export class LanguageServer {
 		/**
 		 * Check Python Version: It checks if the Python version is 3.6 or higher. If not, it exits with status code 4
 		 * Try to Import a Module: It tries to import the inmantals module. If the import is successful, it exits with status code 0.
-		 * Try to Import a Module: It tries to import the inmantals module. If the import is successful, it exits with status code 0.
 		 * Check Virtual Environment: If the script is not running in a virtual environment, it exits with status code 5. Otherwise, it exits with status code 3.
 		 * 
 		 * NOTE: The indenting here is required for the script to work correctly.
@@ -313,12 +312,12 @@ except ModuleNotFoundError:
 	}
 
 	/**
-	* Prompt the user to select a Python interpreter.
-	*
-	* @param {string} diagnoseId a uuid to identify the diagnose
-	* @returns {Promise<any>} A Promise that resolves to the result of startOrRestartLS() after the interpreter is selected.
-	*    If the user cancels the selection, a Promise rejection with the message "No Interpreter Selected" is returned.
-	*/
+	 * Prompt the user to select a Python interpreter.
+	 *
+	 * @param {string} diagnoseId a uuid to identify the diagnose
+	 * @returns {Promise<any>} A Promise that resolves to the result of startOrRestartLS() after the interpreter is selected.
+	 *    If the user cancels the selection, a Promise rejection with the message "No Interpreter Selected" is returned.
+	 */
 	async selectInterpreter(diagnoseId: string): Promise<any> {
 		const response = await window.showErrorMessage(`No interpreter or invalid interpreter selected`, 'Select interpreter');
 

--- a/src/language_server.ts
+++ b/src/language_server.ts
@@ -230,20 +230,24 @@ export class LanguageServer {
 		 * Try to Import a Module: It tries to import the inmantals module. If the import is successful, it exits with status code 0.
 		 * Try to Import a Module: It tries to import the inmantals module. If the import is successful, it exits with status code 0.
 		 * Check Virtual Environment: If the script is not running in a virtual environment, it exits with status code 5. Otherwise, it exits with status code 3.
+		 * 
+		 * NOTE: The indenting here is required for the script to work correctly.
 		 */
-		const script = `import sys
-			if sys.version_info[0] != 3 or sys.version_info[1] < 6:
-				sys.exit(4)
-			try:
-				import inmantals
-				sys.exit(0)
-			except ModuleNotFoundError:
-				real_prefix = getattr(sys, 'real_prefix', None)
-				base_prefix = getattr(sys, 'base_prefix', sys.prefix)
-				running_in_virtualenv = (base_prefix or real_prefix) != sys.prefix
-				if not running_in_virtualenv:
-					sys.exit(5)
-				sys.exit(3)`;
+		const script = `
+import sys
+if sys.version_info[0] != 3 or sys.version_info[1] < 6:
+    sys.exit(4)
+try:
+    import inmantals
+    sys.exit(0)
+except ModuleNotFoundError:
+    real_prefix = getattr(sys, 'real_prefix', None)
+    base_prefix = getattr(sys, 'base_prefix', sys.prefix)
+    running_in_virtualenv = (base_prefix or real_prefix) != sys.prefix
+    if not running_in_virtualenv:
+        sys.exit(5)
+    sys.exit(3)
+`;
 
 		const spawnResult = cp.spawnSync(pythonPath, ["-c", script]);
 		const stdout = spawnResult.stdout.toString();

--- a/src/test/loadExtension/loadExtension.test.ts
+++ b/src/test/loadExtension/loadExtension.test.ts
@@ -4,12 +4,27 @@ import * as path from 'path';
 
 import { Uri, window, commands, workspace, TextDocument, extensions } from 'vscode';
 
-const cfFile: Uri = Uri.file(path.resolve(__dirname, '../../../src/test/compile/workspace/valid.cf'));
+const workspaceUri: Uri = Uri.file(path.resolve(__dirname, '../../../src/test/loadExtension/workspace'));
+const cfFile: Uri = Uri.file(path.resolve(workspaceUri.fsPath, 'main.cf'));
+const textFile: Uri = Uri.file(path.resolve(workspaceUri.fsPath, 'textFile.txt'));
 
 describe('Load extension', () => {
 
     beforeEach(async function () {
         await commands.executeCommand('workbench.action.closeActiveEditor');
+    });
+
+    it('Load .txt file will not start the Extension', async function () {
+        // Verify initial state
+        let inmanta = extensions.getExtension('inmanta.inmanta');
+        assert.ok(!inmanta.isActive, 'Inmanta extension is not started');
+
+        // Open a single file instead of a folder
+        await commands.executeCommand('vscode.open', textFile);
+        const doc: TextDocument = await workspace.openTextDocument(textFile);
+        await window.showTextDocument(doc);
+        inmanta = extensions.getExtension('inmanta.inmanta');
+        assert.ok(!inmanta.isActive, 'Inmanta extension is not started');
     });
 
     it('Load .cf file will start the Extension', async function () {

--- a/src/test/loadExtension/workspace/main.cf
+++ b/src/test/loadExtension/workspace/main.cf
@@ -1,12 +1,6 @@
-import testmodule
-
-"""
-A class to represent a person.
-"""
 entity Person:
     string name
     int age
-    testmodule::pet pet
 end
 
 Person.friends [0:] -- Person
@@ -16,10 +10,10 @@ index Person(name)
 implement Person using std::none
 
 john = Person(name="John", age=20)
-mike = Person(name="Mike", age=12, pet="dinosaur")
-jane = Person(name="Jane", age=19, pet="bird")
+mike = Person(name="Mike", age=21)
+jane = Person(name="Jane", age=19)
 lucy = Person(name="Lucy", age=23)
-testmodule::noop(mike.pet)
+
 john.friends += mike
 john.friends += jane
 

--- a/src/test/loadExtension/workspace/project.yml
+++ b/src/test/loadExtension/workspace/project.yml
@@ -1,0 +1,5 @@
+name: test-project
+modulepath: libs
+downloadpath: libs
+repo: https://github.com/inmanta/
+description: Test project for the vscode inmanta extension

--- a/src/test/loadExtension/workspace/textFile.txt
+++ b/src/test/loadExtension/workspace/textFile.txt
@@ -1,0 +1,1 @@
+This is a normal text file.

--- a/src/test/navigation/navigation.test.ts
+++ b/src/test/navigation/navigation.test.ts
@@ -44,20 +44,6 @@ describe('Language Server Code navigation', () => {
 		});
 	}).timeout(0);
 
-	it(`Check that hovering over a symbol displays the correct information`, () => {
-		return new Promise<void>(async resolve => {
-			// Open model file
-			const doc: TextDocument = await workspace.openTextDocument(modelUri);
-			await window.showTextDocument(doc);
-			const succeeded = await waitForCompile(logPath, 25000);
-			assert.strictEqual(succeeded, true, "Compilation didn't succeed");
-			const hoverInfo = await commands.executeCommand("vscode.executeHoverProvider", modelUri, new Position(13, 16));
-			assert.strictEqual((hoverInfo as any[]).length, 1, "Hover information should be displayed");
-			assert.strictEqual((hoverInfo as any[])[0].contents[0].value, "\n```inmanta\nstring name\n```\n\n___\n", "Hover information doesn't match");
-			resolve();
-		});
-	}).timeout(0);
-
 	it(`Check that code navigation to a non-existent symbol returns no locations`, () => {
 		return new Promise<void>(async resolve => {
 			// Open model file

--- a/src/test/navigation/navigation.test.ts
+++ b/src/test/navigation/navigation.test.ts
@@ -44,19 +44,6 @@ describe('Language Server Code navigation', () => {
 		});
 	}).timeout(0);
 
-	it(`Check that code navigation to a non-existent symbol returns no locations`, () => {
-		return new Promise<void>(async resolve => {
-			// Open model file
-			const doc: TextDocument = await workspace.openTextDocument(modelUri);
-			await window.showTextDocument(doc);
-			const succeeded = await waitForCompile(logPath, 25000);
-			assert.strictEqual(succeeded, true, "Compilation didn't succeed");
-			const nonExistentSymbol = await commands.executeCommand("vscode.executeDefinitionProvider", modelUri, new Position(20, 20));
-			assert.strictEqual((nonExistentSymbol as Location[]).length, 0, "Non-existent symbol should return no locations");
-			resolve();
-		});
-	}).timeout(0);
-
 	it(`Check that hovering over a symbol displays the correct information`, () => {
 		return new Promise<void>(async resolve => {
 			// Open model file

--- a/src/test/navigation/navigation.test.ts
+++ b/src/test/navigation/navigation.test.ts
@@ -25,19 +25,18 @@ describe('Language Server Code navigation', () => {
 			await window.showTextDocument(doc);
 			const succeeded = await waitForCompile(logPath, 25000);
 			assert.strictEqual(succeeded, true, "Compilation didn't succeed");
-			const attributeInSameFile = await commands.executeCommand("vscode.executeDefinitionProvider", modelUri, new Position(13, 16));
-			const expectedAttributeLocation = new Range(new Position(2, 11), new Position(2, 15));
+			const attributeInSameFile = await commands.executeCommand("vscode.executeDefinitionProvider", modelUri, new Position(17, 16));
+			const expectedAttributeLocation = new Range(new Position(6, 11), new Position(6, 15));
 			assert.strictEqual((attributeInSameFile as Location[]).length, 1);
 			assert.strictEqual(attributeInSameFile[0].uri.fsPath, modelUri.fsPath);
 			assert.deepStrictEqual(attributeInSameFile[0].range, expectedAttributeLocation, "Attribute location in the same file doesn't match");
 
-			const typeInDifferentFile = await commands.executeCommand("vscode.executeDefinitionProvider", modelUri, new Position(4, 18));
+			const typeInDifferentFile = await commands.executeCommand("vscode.executeDefinitionProvider", modelUri, new Position(8, 18));
 			assert.strictEqual((typeInDifferentFile as Location[]).length, 1);
 			assert.strictEqual(typeInDifferentFile[0].uri.fsPath, path.resolve(libsPath, "testmodule", "model", "_init.cf"));
 			assert.deepStrictEqual(typeInDifferentFile[0].range, new Range(new Position(0, 8), new Position(0, 11)), "Attribute location in different file doesn't match");
 
-
-			const pluginLocation = await commands.executeCommand("vscode.executeDefinitionProvider", modelUri, new Position(17, 15));
+			const pluginLocation = await commands.executeCommand("vscode.executeDefinitionProvider", modelUri, new Position(21, 15));
 			assert.strictEqual((pluginLocation as Location[]).length, 1);
 			assert.strictEqual(pluginLocation[0].uri.fsPath, path.resolve(libsPath, "testmodule", "plugins", "__init__.py"));
 			assert.deepStrictEqual(pluginLocation[0].range, new Range(new Position(4, 4), new Position(4, 8)), "Plugin location doesn't match");
@@ -45,6 +44,45 @@ describe('Language Server Code navigation', () => {
 		});
 	}).timeout(0);
 
+	it(`Check that code navigation to a non-existent symbol returns no locations`, () => {
+		return new Promise<void>(async resolve => {
+			// Open model file
+			const doc: TextDocument = await workspace.openTextDocument(modelUri);
+			await window.showTextDocument(doc);
+			const succeeded = await waitForCompile(logPath, 25000);
+			assert.strictEqual(succeeded, true, "Compilation didn't succeed");
+			const nonExistentSymbol = await commands.executeCommand("vscode.executeDefinitionProvider", modelUri, new Position(20, 20));
+			assert.strictEqual((nonExistentSymbol as Location[]).length, 0, "Non-existent symbol should return no locations");
+			resolve();
+		});
+	}).timeout(0);
+
+	it(`Check that hovering over a symbol displays the correct information`, () => {
+		return new Promise<void>(async resolve => {
+			// Open model file
+			const doc: TextDocument = await workspace.openTextDocument(modelUri);
+			await window.showTextDocument(doc);
+			const succeeded = await waitForCompile(logPath, 25000);
+			assert.strictEqual(succeeded, true, "Compilation didn't succeed");
+			const hoverInfo = await commands.executeCommand("vscode.executeHoverProvider", modelUri, new Position(13, 16));
+			assert.strictEqual((hoverInfo as any[]).length, 1, "Hover information should be displayed");
+			assert.strictEqual((hoverInfo as any[])[0].contents[0].value, "\n```inmanta\nstring name\n```\n\n___\n", "Hover information doesn't match");
+			resolve();
+		});
+	}).timeout(0);
+
+	it(`Check that code navigation to a non-existent symbol returns no locations`, () => {
+		return new Promise<void>(async resolve => {
+			// Open model file
+			const doc: TextDocument = await workspace.openTextDocument(modelUri);
+			await window.showTextDocument(doc);
+			const succeeded = await waitForCompile(logPath, 25000);
+			assert.strictEqual(succeeded, true, "Compilation didn't succeed");
+			const nonExistentSymbol = await commands.executeCommand("vscode.executeDefinitionProvider", modelUri, new Position(20, 20));
+			assert.strictEqual((nonExistentSymbol as Location[]).length, 0, "Non-existent symbol should return no locations");
+			resolve();
+		});
+	}).timeout(0);
 
 	after(async () => {
 		await Promise.all([


### PR DESCRIPTION
# Description

- Added test cases for: 
   - Opening a non .cf file wouldn't trigger the extention
   - Clicking on a symbol that has no reference shouldn't relocate/navigate

The loadExtention test was cross using a file from a the compile mocked workspace. I added a mocked worskpace for the loadExtention.

Adding code coverage report isn't built in for Hosted Extention tests, and would require too much work for small gains. 