### PR TITLE
Fix IndexError (list index out of range) in textDocument/hover

### DIFF
--- a/server/src/inmantals/server.py
+++ b/server/src/inmantals/server.py
@@ -790,6 +790,10 @@ class InmantaLSHandler(JsonRpcHandler):
             # Certain keywords e.g. "Entity" are defined internally in virtual files (e.g. 'internal').
             # Display nothing on hover if the hovered symbol is defined in a file that doesn't exist:
             return {}
+        except IndexError:
+            # The anchor's location can point at a line number that no longer exists in its file,
+            # e.g. because of a stale anchormap. Display nothing on hover instead of crashing.
+            return {}
 
         language = self.get_file_type(data.location.file)
         definition_md = f"""

--- a/server/tests/test_smoke.py
+++ b/server/tests/test_smoke.py
@@ -29,9 +29,12 @@ from tornado.iostream import IOStream
 from tornado.tcpclient import TCPClient
 
 from inmanta import env
+from inmanta.ast import Location
 from inmantals import lsp_types
 from inmantals.jsonrpc import JsonRpcServer
-from inmantals.server import CORE_VERSION, InmantaLSHandler
+from inmantals.server import CORE_VERSION, AnchorTarget, InmantaLSHandler
+from intervaltree.interval import Interval
+from intervaltree.intervaltree import IntervalTree
 from packaging import version
 
 
@@ -478,3 +481,37 @@ async def test_unspecified_workspace_folder(client: JsonRPC) -> None:
     """
     await client.call("initialize", workspaceFolders=None, capabilities={})
     await client.assert_error(message="No workspace folder or rootUri specified.")
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_hover_definition_out_of_range(tmp_path) -> None:
+    """
+    The hover handler should degrade gracefully (return no hover result) instead of raising an
+    unhandled IndexError when the anchor target it resolves to points at a line number beyond
+    the end of its own file.
+
+    This reproduces the "list index out of range" crash reported in
+    https://github.com/inmanta/vscode-inmanta/issues/1219, where the client received:
+        Request textDocument/hover failed.
+        Message: list index out of range
+    """
+    definition_file = tmp_path / "definition.cf"
+    definition_file.write_text("entity Foo:\nend\n")
+
+    hovered_file = tmp_path / "hovered.cf"
+    hovered_file.write_text("Foo()\n")
+    hovered_path = os.path.realpath(str(hovered_file))
+    hovered_uri = f"file://{hovered_path}"
+
+    # Points at line 100 of a 2-line file: out of range for readlines()[start_line].
+    target = AnchorTarget(location=Location(str(definition_file), 100), docstring=None)
+
+    handler = InmantaLSHandler.__new__(InmantaLSHandler)
+    handler.anchormap = {hovered_path: IntervalTree([Interval(handler.flatten(0, 0), handler.flatten(0, 5) + 1, target)])}
+
+    result = await handler.textDocument_hover(
+        textDocument={"uri": hovered_uri},
+        position={"line": 0, "character": 0},
+    )
+    assert result == {}


### PR DESCRIPTION
## What

Catches `IndexError` in `textDocument_hover`, the same way `FileNotFoundError` is already handled a few lines above, and returns an empty hover result instead of letting it propagate.

## Why

`get_definition()` reads the definition line via:

```python
with open(file_path, "r", encoding="utf8") as f:
    line = f.readlines()[start_line]
```

`start_line` comes from the anchor target's `location.lnr`. When that line number does not exist in the target file (e.g. because of a stale or inconsistent anchor entry), `readlines()[start_line]` raises `IndexError`, which is not caught anywhere in `textDocument_hover`. The client then surfaces this as an unhandled RPC error:

```
Request textDocument/hover failed.
  Message: list index out of range
  Code: -32603
```

This matches the exact error message reported in #1219. There is already a precedent for degrading gracefully on hover when the target can't be resolved (`except FileNotFoundError: return {}` for the "defined internally in a virtual file" case), so this applies the same treatment to the out-of-range case.

Fixes #1219

## Testing

Added `test_hover_definition_out_of_range` in `server/tests/test_smoke.py`, which builds a minimal `anchormap` whose target points past the end of a temp file and asserts `textDocument_hover` returns `{}` instead of raising.

- Confirmed red against current `master` (`22081304`): the new test fails with `IndexError: list index out of range`, raised from `get_definition`, reproducing the reported crash.
- Green after the fix: `python -m pytest tests/test_smoke.py::test_hover_definition_out_of_range` passes.
- Full server suite (`python -m pytest tests/`): same pass/fail set before and after this change (one pre-existing, environment-specific failure in `test_working_on_v2_modules` unrelated to hover, caused by a local venv-in-venv dylib loading issue, not by this diff).
- `flake8 src tests` (the `pep8` tox target): clean.
- `black --check` / `isort --check`: clean.
